### PR TITLE
Removed RedisDep from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,13 @@ pip install fastapi-redis-sdk
 
 ```python
 from fastapi import FastAPI
-from redis_fastapi import FastAPIRedis, RedisDep, AsyncRedisDep
+from redis_fastapi import FastAPIRedis, AsyncRedisDep
 
 app = FastAPI()
 FastAPIRedis(app).lifespan()
 
 @app.get("/items")
-def get_items(redis: RedisDep):
-    return {"items": redis.get("items")}
-
-@app.get("/async-items")
-async def get_items_async(redis: AsyncRedisDep):
+async def get_items(redis: AsyncRedisDep):
     return {"items": await redis.get("items")}
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -161,7 +161,7 @@ export REDIS_CLUSTER=true
 export REDIS_URL=redis://node1:6379,node2:6379,node3:6379
 ```
 
-When enabled, `RedisDep` yields a `RedisCluster` and `AsyncRedisDep` yields an `AsyncRedisCluster`.
+When enabled, `AsyncRedisDep` yields an `AsyncRedisCluster`.
 
 ## Key Prefix
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,17 +43,13 @@ requirements and alternative package managers.
 
 ```python
 from fastapi import FastAPI
-from redis_fastapi import FastAPIRedis, RedisDep, AsyncRedisDep
+from redis_fastapi import FastAPIRedis, AsyncRedisDep
 
 app = FastAPI()
 FastAPIRedis(app).lifespan()
 
 @app.get("/items")
-def get_items(redis: RedisDep):
-    return {"items": redis.get("items")}
-
-@app.get("/async-items")
-async def get_items_async(redis: AsyncRedisDep):
+async def get_items(redis: AsyncRedisDep):
     return {"items": await redis.get("items")}
 ```
 


### PR DESCRIPTION
It looks like `RedisDep` is no longer in the API. The examples still mention it, so I've attempted to fix them.