### PR TITLE
Introduced FastAPIJsonCoder for JSON encoding of FastAPI-compatible values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Idiomatic Redis integration for FastAPI - connection management and DI-based cac
 - **Fluent setup** — `FastAPIRedis(app).lifespan().caching()` configures pools and caching in one chain, attaching to the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/)
 - **Dependency injection** — `cache()`, `cache_evict()`, `cache_put()` as `Depends()` factories, plus `CacheBackend` for complex invalidation and conditional logic
 - **HTTP-native caching** — [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag), [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304), [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) directives out of the box
-- **FastAPI-aware serialization** — optional coders for Pydantic models, datetimes, UUIDs, and other `jsonable_encoder`-compatible values
 - **Testable** — full `dependency_overrides` support; no need for monkey-patching
 - **Pydantic-validated configuration** — fully configurable via environment variables or via an `.env` file
 
@@ -120,37 +119,6 @@ async def dashboard(user_id: int, cache: CacheBackendDep):
 ```
 
 Provides `get`/`set`/`delete`/`has`/`delete_group` with automatic JSON serialization. Use it for conditional caching, cascade invalidation, dynamic TTL, and intermediate result caching.
-
-For values that FastAPI can serialize but stdlib `json.dumps()` cannot
-handle directly, use `FastAPIJsonCoder`. For typed model round-trips, create a
-Pydantic model coder:
-
-```python
-from typing import Annotated
-from fastapi import Depends
-from pydantic import BaseModel
-from redis_fastapi import AsyncRedisDep, CacheBackend, pydantic_model_coder
-
-class Product(BaseModel):
-    id: int
-    name: str
-
-ProductCoder = pydantic_model_coder(Product)
-
-async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
-    return CacheBackend(redis, coder=ProductCoder)
-
-ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
-
-@app.get("/products/{product_id}")
-async def product(product_id: int, cache: ProductCacheDep) -> Product:
-    cached = await cache.get(f"product:{product_id}")
-    if cached is not None:
-        return cached
-    product = await db.get_product(product_id)
-    await cache.set(f"product:{product_id}", product, ttl=300)
-    return product
-```
 
 See the [Caching Guide](docs/guide/caching.md) for detailed examples, feature comparison, and best practices.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Idiomatic Redis integration for FastAPI - connection management and DI-based cac
 - **Fluent setup** — `FastAPIRedis(app).lifespan().caching()` configures pools and caching in one chain, attaching to the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/)
 - **Dependency injection** — `cache()`, `cache_evict()`, `cache_put()` as `Depends()` factories, plus `CacheBackend` for complex invalidation and conditional logic
 - **HTTP-native caching** — [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag), [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304), [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) directives out of the box
+- **FastAPI-aware serialization** — optional coders for Pydantic models, datetimes, UUIDs, and other `jsonable_encoder`-compatible values
 - **Testable** — full `dependency_overrides` support; no need for monkey-patching
 - **Pydantic-validated configuration** — fully configurable via environment variables or via an `.env` file
 
@@ -119,6 +120,37 @@ async def dashboard(user_id: int, cache: CacheBackendDep):
 ```
 
 Provides `get`/`set`/`delete`/`has`/`delete_group` with automatic JSON serialization. Use it for conditional caching, cascade invalidation, dynamic TTL, and intermediate result caching.
+
+For values that FastAPI can serialize but stdlib `json.dumps()` cannot
+handle directly, use `FastAPIJsonCoder`. For typed model round-trips, create a
+Pydantic model coder:
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from pydantic import BaseModel
+from redis_fastapi import AsyncRedisDep, CacheBackend, pydantic_model_coder
+
+class Product(BaseModel):
+    id: int
+    name: str
+
+ProductCoder = pydantic_model_coder(Product)
+
+async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
+    return CacheBackend(redis, coder=ProductCoder)
+
+ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
+
+@app.get("/products/{product_id}")
+async def product(product_id: int, cache: ProductCacheDep) -> Product:
+    cached = await cache.get(f"product:{product_id}")
+    if cached is not None:
+        return cached
+    product = await db.get_product(product_id)
+    await cache.set(f"product:{product_id}", product, ttl=300)
+    return product
+```
 
 See the [Caching Guide](docs/guide/caching.md) for detailed examples, feature comparison, and best practices.
 

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -134,6 +134,53 @@ class Coder(Protocol):
 
 Default `Coder` implementation using `json.dumps` / `json.loads`.
 
+### `FastAPIJsonCoder`
+
+```python
+from redis_fastapi import FastAPIJsonCoder
+```
+
+JSON coder that runs values through FastAPI's `jsonable_encoder()` before
+calling `json.dumps()`. Use it for cache values containing Pydantic models,
+`datetime`, `UUID`, enums, dataclasses, and other FastAPI-compatible values.
+
+```python
+from redis_fastapi import CacheBackend, FastAPIJsonCoder
+
+cache = CacheBackend(redis, coder=FastAPIJsonCoder)
+await cache.set("item:1", item)
+```
+
+### `pydantic_model_coder()`
+
+```python
+from redis_fastapi import pydantic_model_coder
+
+ProductCoder = pydantic_model_coder(Product)
+```
+
+Creates a `Coder` class for one Pydantic model type. Encoded values can be
+model instances or data that Pydantic can validate into that model; decoded
+values are returned as model instances.
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from pydantic import BaseModel
+from redis_fastapi import AsyncRedisDep, CacheBackend, pydantic_model_coder
+
+class Product(BaseModel):
+    id: int
+    name: str
+
+ProductCoder = pydantic_model_coder(Product)
+
+async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
+    return CacheBackend(redis, coder=ProductCoder)
+
+ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
+```
+
 ### `KeyBuilder`
 
 ```python
@@ -141,4 +188,3 @@ KeyBuilder = Callable[..., str | Awaitable[str]]
 ```
 
 Callable that receives `(request, eviction_group, prefix)` and returns a cache key.
-

--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -134,23 +134,6 @@ class Coder(Protocol):
 
 Default `Coder` implementation using `json.dumps` / `json.loads`.
 
-### `FastAPIJsonCoder`
-
-```python
-from redis_fastapi import FastAPIJsonCoder
-```
-
-JSON coder that runs values through FastAPI's `jsonable_encoder()` before
-calling `json.dumps()`. Use it for cache values containing Pydantic models,
-`datetime`, `UUID`, enums, dataclasses, and other FastAPI-compatible values.
-
-```python
-from redis_fastapi import CacheBackend, FastAPIJsonCoder
-
-cache = CacheBackend(redis, coder=FastAPIJsonCoder)
-await cache.set("item:1", item)
-```
-
 ### `pydantic_model_coder()`
 
 ```python
@@ -162,6 +145,10 @@ ProductCoder = pydantic_model_coder(Product)
 Creates a `Coder` class for one Pydantic model type. Encoded values can be
 model instances or data that Pydantic can validate into that model; decoded
 values are returned as model instances.
+
+Because the coder is model-specific, select it the DI-native way — declare a
+model-specific `CacheBackend` provider and inject it (the default
+`CacheBackendDep` keeps `JsonCoder`):
 
 ```python
 from typing import Annotated
@@ -176,7 +163,7 @@ class Product(BaseModel):
 ProductCoder = pydantic_model_coder(Product)
 
 async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
-    return CacheBackend(redis, coder=ProductCoder)
+    return CacheBackend(redis, coder=ProductCoder, eviction_group="products")
 
 ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
 ```

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -65,6 +65,11 @@ async def dashboard(user_id: int, cache: CacheBackendDep):
 
 `Annotated[CacheBackend, Depends(get_cache_backend)]` — async cache backend with `get`/`set`/`delete`/`has`/`delete_group`. Use for conditional caching, cascade invalidation, and dynamic TTL.
 
+`CacheBackend(redis, coder=...)` accepts any `Coder`. Use `FastAPIJsonCoder`
+for values supported by FastAPI's `jsonable_encoder()`, or
+`pydantic_model_coder(Model)` when cache hits should decode back into Pydantic
+model instances.
+
 ### `SyncCacheBackendDep`
 
 ```python
@@ -165,4 +170,3 @@ def default_key_builder(request: Request, eviction_group: str = "", prefix: str 
 ```
 
 Builds a cache key from the request path (slashes → colons) and sorted query params. Eviction group is wrapped in Redis hash-tag braces (`{eviction_group}`) for Cluster slot consistency.
-

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -65,8 +65,7 @@ async def dashboard(user_id: int, cache: CacheBackendDep):
 
 `Annotated[CacheBackend, Depends(get_cache_backend)]` — async cache backend with `get`/`set`/`delete`/`has`/`delete_group`. Use for conditional caching, cascade invalidation, and dynamic TTL.
 
-`CacheBackend(redis, coder=...)` accepts any `Coder`. Use `FastAPIJsonCoder`
-for values supported by FastAPI's `jsonable_encoder()`, or
+`CacheBackend(redis, coder=...)` accepts any `Coder`. Use
 `pydantic_model_coder(Model)` when cache hits should decode back into Pydantic
 model instances.
 

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -296,6 +296,49 @@ pattern (get → miss → compute → set → return) is exactly what `cache()` 
 automatically.  Use `CacheBackendDep` when you need control that the DI
 factories cannot express:
 
+### FastAPI-aware serialization
+
+By default, `CacheBackend` uses `JsonCoder`, a thin wrapper around
+`json.dumps()` / `json.loads()`. Use `FastAPIJsonCoder` when cached values
+contain objects FastAPI already knows how to serialize, such as Pydantic
+models, `datetime`, `UUID`, enums, or dataclasses:
+
+```python
+from redis_fastapi import CacheBackend, FastAPIJsonCoder
+
+cache = CacheBackend(redis, coder=FastAPIJsonCoder)
+```
+
+For typed model round-trips, create a model-specific coder. Decoded cache hits
+come back as Pydantic model instances:
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from pydantic import BaseModel
+from redis_fastapi import AsyncRedisDep, CacheBackend, pydantic_model_coder
+
+class Product(BaseModel):
+    id: int
+    name: str
+
+ProductCoder = pydantic_model_coder(Product)
+
+async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
+    return CacheBackend(redis, coder=ProductCoder)
+
+ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
+
+@app.get("/products/{product_id}")
+async def get_product(product_id: int, cache: ProductCacheDep) -> Product:
+    cached = await cache.get(f"product:{product_id}", eviction_group="products")
+    if cached is not None:
+        return cached
+    product = await db.get_product(product_id)
+    await cache.set(f"product:{product_id}", product, ttl=300, eviction_group="products")
+    return product
+```
+
 ### Conditional caching
 
 Cache only when business rules are met - `@cache` always caches the result:

--- a/docs/guide/caching.md
+++ b/docs/guide/caching.md
@@ -296,48 +296,56 @@ pattern (get → miss → compute → set → return) is exactly what `cache()` 
 automatically.  Use `CacheBackendDep` when you need control that the DI
 factories cannot express:
 
-### FastAPI-aware serialization
+### Caching Pydantic models
 
 By default, `CacheBackend` uses `JsonCoder`, a thin wrapper around
-`json.dumps()` / `json.loads()`. Use `FastAPIJsonCoder` when cached values
-contain objects FastAPI already knows how to serialize, such as Pydantic
-models, `datetime`, `UUID`, enums, or dataclasses:
+`json.dumps()` / `json.loads()`, which cannot serialize Pydantic models,
+`datetime`, `UUID`, enums, or `Decimal`. To cache a Pydantic model, wrap it with
+`pydantic_model_coder()`: the resulting coder serializes with the model's own
+JSON encoder on write and validates back into a model instance on read, so cache
+hits come back fully typed.
 
-```python
-from redis_fastapi import CacheBackend, FastAPIJsonCoder
-
-cache = CacheBackend(redis, coder=FastAPIJsonCoder)
-```
-
-For typed model round-trips, create a model-specific coder. Decoded cache hits
-come back as Pydantic model instances:
+Because a coder is model-specific, you select it the **DI-native** way — by
+declaring a model-specific `CacheBackend` provider and injecting it, exactly as
+you would with `get_db` or `get_current_user`. The default `CacheBackendDep`
+stays on `JsonCoder`; this provider is a parallel dependency that carries the
+`Product` coder (and its eviction group):
 
 ```python
 from typing import Annotated
+from datetime import datetime
+from uuid import UUID
+
 from fastapi import Depends
 from pydantic import BaseModel
 from redis_fastapi import AsyncRedisDep, CacheBackend, pydantic_model_coder
 
 class Product(BaseModel):
-    id: int
+    id: UUID
     name: str
+    created_at: datetime
 
+# Wire the coder into a model-specific CacheBackend provider, then alias it.
 ProductCoder = pydantic_model_coder(Product)
 
 async def get_product_cache(redis: AsyncRedisDep) -> CacheBackend:
-    return CacheBackend(redis, coder=ProductCoder)
+    return CacheBackend(redis, coder=ProductCoder, eviction_group="products")
 
 ProductCacheDep = Annotated[CacheBackend, Depends(get_product_cache)]
 
 @app.get("/products/{product_id}")
-async def get_product(product_id: int, cache: ProductCacheDep) -> Product:
-    cached = await cache.get(f"product:{product_id}", eviction_group="products")
+async def get_product(product_id: UUID, cache: ProductCacheDep) -> Product:
+    cached = await cache.get(f"product:{product_id}")
     if cached is not None:
-        return cached
+        return cached                          # a real Product instance, fully typed
     product = await db.get_product(product_id)
-    await cache.set(f"product:{product_id}", product, ttl=300, eviction_group="products")
+    await cache.set(f"product:{product_id}", product, ttl=300)
     return product
 ```
+
+`get_product_cache` reuses the shared connection pool via `AsyncRedisDep`, so the
+model-specific backend costs nothing extra beyond the coder. Add one such
+provider per model you cache.
 
 ### Conditional caching
 

--- a/src/redis_fastapi/__init__.py
+++ b/src/redis_fastapi/__init__.py
@@ -23,7 +23,13 @@ from redis_fastapi.deps import (
 from redis_fastapi.lifespan import redis_lifespan
 from redis_fastapi.setup import FastAPIRedis
 from redis_fastapi.telemetry import disable_telemetry, enable_telemetry
-from redis_fastapi.types import Coder, JsonCoder, KeyBuilder
+from redis_fastapi.types import (
+    Coder,
+    FastAPIJsonCoder,
+    JsonCoder,
+    KeyBuilder,
+    pydantic_model_coder,
+)
 
 __all__ = [
     "AsyncRedisDep",
@@ -31,6 +37,7 @@ __all__ = [
     "CacheBackendDep",
     "CacheHitException",
     "Coder",
+    "FastAPIJsonCoder",
     "JsonCoder",
     "KeyBuilder",
     "FastAPIRedis",
@@ -48,5 +55,6 @@ __all__ = [
     "get_cache_backend",
     "get_settings",
     "get_sync_cache_backend",
+    "pydantic_model_coder",
     "redis_lifespan",
 ]

--- a/src/redis_fastapi/__init__.py
+++ b/src/redis_fastapi/__init__.py
@@ -25,7 +25,6 @@ from redis_fastapi.setup import FastAPIRedis
 from redis_fastapi.telemetry import disable_telemetry, enable_telemetry
 from redis_fastapi.types import (
     Coder,
-    FastAPIJsonCoder,
     JsonCoder,
     KeyBuilder,
     pydantic_model_coder,
@@ -37,7 +36,6 @@ __all__ = [
     "CacheBackendDep",
     "CacheHitException",
     "Coder",
-    "FastAPIJsonCoder",
     "JsonCoder",
     "KeyBuilder",
     "FastAPIRedis",

--- a/src/redis_fastapi/types.py
+++ b/src/redis_fastapi/types.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypeVar, runtime_checkable
+
+from fastapi.encoders import jsonable_encoder
+from pydantic import BaseModel
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
 @runtime_checkable
@@ -28,6 +33,44 @@ class JsonCoder:
     @classmethod
     def decode(cls, value: str) -> Any:
         return json.loads(value)
+
+
+class FastAPIJsonCoder:
+    """JSON coder that first converts values with FastAPI's encoder."""
+
+    @classmethod
+    def encode(cls, value: Any) -> str:
+        return json.dumps(jsonable_encoder(value))
+
+    @classmethod
+    def decode(cls, value: str) -> Any:
+        return json.loads(value)
+
+
+def pydantic_model_coder(model_type: type[ModelT]) -> type[Coder]:
+    """Create a coder that decodes cached JSON back into *model_type*.
+
+    The returned coder accepts either an instance of *model_type* or data that
+    Pydantic can validate into that model.
+    """
+
+    class _PydanticModelCoder:
+        @classmethod
+        def encode(cls, value: Any) -> str:
+            model: ModelT
+            if isinstance(value, model_type):
+                model = value
+            else:
+                model = model_type.model_validate(value)
+            return model.model_dump_json()
+
+        @classmethod
+        def decode(cls, value: str) -> ModelT:
+            return model_type.model_validate_json(value)
+
+    _PydanticModelCoder.__name__ = f"{model_type.__name__}Coder"
+    _PydanticModelCoder.__qualname__ = _PydanticModelCoder.__name__
+    return _PydanticModelCoder
 
 
 # A key builder receives (request, eviction_group, prefix) and returns a cache key.

--- a/src/redis_fastapi/types.py
+++ b/src/redis_fastapi/types.py
@@ -6,7 +6,6 @@ import json
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, TypeAlias, TypeVar, runtime_checkable
 
-from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
@@ -29,18 +28,6 @@ class JsonCoder:
     @classmethod
     def encode(cls, value: Any) -> str:
         return json.dumps(value)
-
-    @classmethod
-    def decode(cls, value: str) -> Any:
-        return json.loads(value)
-
-
-class FastAPIJsonCoder:
-    """JSON coder that first converts values with FastAPI's encoder."""
-
-    @classmethod
-    def encode(cls, value: Any) -> str:
-        return json.dumps(jsonable_encoder(value))
 
     @classmethod
     def decode(cls, value: str) -> Any:

--- a/tests/unit/test_coder.py
+++ b/tests/unit/test_coder.py
@@ -1,7 +1,14 @@
-"""Tests for JsonCoder encode/decode."""
+"""Tests for cache coders."""
 
+from datetime import datetime, timezone
+from uuid import UUID
+
+import fakeredis.aioredis
 import pytest
+from pydantic import BaseModel
 
+import redis_fastapi.types as types
+from redis_fastapi.cache_backend import CacheBackend
 from redis_fastapi.types import Coder, JsonCoder
 
 
@@ -56,3 +63,108 @@ class TestCustomCoder:
 
         assert isinstance(ReverseCoder(), Coder)
         assert ReverseCoder.decode(ReverseCoder.encode("hello")) == "hello"
+
+
+class Product(BaseModel):
+    id: UUID
+    name: str
+    created_at: datetime
+
+
+@pytest.mark.unit
+class TestFastAPIJsonCoder:
+    def test_encodes_fastapi_json_compatible_values(self) -> None:
+        data = {
+            "id": UUID("12345678-1234-5678-1234-567812345678"),
+            "created_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        }
+
+        decoded = types.FastAPIJsonCoder.decode(types.FastAPIJsonCoder.encode(data))
+
+        assert decoded == {
+            "id": "12345678-1234-5678-1234-567812345678",
+            "created_at": "2026-01-02T03:04:05+00:00",
+        }
+
+    def test_encodes_pydantic_model_to_json_compatible_dict(self) -> None:
+        product = Product(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            name="Widget",
+            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+
+        decoded = types.FastAPIJsonCoder.decode(types.FastAPIJsonCoder.encode(product))
+
+        assert decoded == {
+            "id": "12345678-1234-5678-1234-567812345678",
+            "name": "Widget",
+            "created_at": "2026-01-02T03:04:05Z",
+        }
+
+    def test_satisfies_coder_protocol(self) -> None:
+        assert issubclass(types.FastAPIJsonCoder, Coder)
+
+
+@pytest.mark.unit
+class TestPydanticModelCoder:
+    def test_decodes_to_pydantic_model(self) -> None:
+        product = Product(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            name="Widget",
+            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+        coder = types.pydantic_model_coder(Product)
+
+        decoded = coder.decode(coder.encode(product))
+
+        assert decoded == product
+
+    def test_encodes_json_compatible_dict_and_decodes_model(self) -> None:
+        coder = types.pydantic_model_coder(Product)
+
+        decoded = coder.decode(
+            coder.encode(
+                {
+                    "id": "12345678-1234-5678-1234-567812345678",
+                    "name": "Widget",
+                    "created_at": "2026-01-02T03:04:05Z",
+                }
+            )
+        )
+
+        assert decoded == Product(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            name="Widget",
+            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+
+    def test_satisfies_coder_protocol(self) -> None:
+        assert issubclass(types.pydantic_model_coder(Product), Coder)
+
+
+@pytest.mark.unit
+class TestCoderExports:
+    def test_fastapi_coders_exported_from_package_root(self) -> None:
+        from redis_fastapi import FastAPIJsonCoder, pydantic_model_coder
+
+        assert FastAPIJsonCoder is types.FastAPIJsonCoder
+        assert pydantic_model_coder is types.pydantic_model_coder
+
+
+@pytest.mark.unit
+class TestCoderWithCacheBackend:
+    @pytest.mark.asyncio
+    async def test_pydantic_model_coder_round_trips_through_cache_backend(
+        self,
+    ) -> None:
+        fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        cache = CacheBackend(fake, coder=types.pydantic_model_coder(Product))
+        product = Product(
+            id=UUID("12345678-1234-5678-1234-567812345678"),
+            name="Widget",
+            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )
+
+        await cache.set("product:1", product, eviction_group="products")
+
+        assert await cache.get("product:1", eviction_group="products") == product

--- a/tests/unit/test_coder.py
+++ b/tests/unit/test_coder.py
@@ -72,40 +72,6 @@ class Product(BaseModel):
 
 
 @pytest.mark.unit
-class TestFastAPIJsonCoder:
-    def test_encodes_fastapi_json_compatible_values(self) -> None:
-        data = {
-            "id": UUID("12345678-1234-5678-1234-567812345678"),
-            "created_at": datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
-        }
-
-        decoded = types.FastAPIJsonCoder.decode(types.FastAPIJsonCoder.encode(data))
-
-        assert decoded == {
-            "id": "12345678-1234-5678-1234-567812345678",
-            "created_at": "2026-01-02T03:04:05+00:00",
-        }
-
-    def test_encodes_pydantic_model_to_json_compatible_dict(self) -> None:
-        product = Product(
-            id=UUID("12345678-1234-5678-1234-567812345678"),
-            name="Widget",
-            created_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
-        )
-
-        decoded = types.FastAPIJsonCoder.decode(types.FastAPIJsonCoder.encode(product))
-
-        assert decoded == {
-            "id": "12345678-1234-5678-1234-567812345678",
-            "name": "Widget",
-            "created_at": "2026-01-02T03:04:05Z",
-        }
-
-    def test_satisfies_coder_protocol(self) -> None:
-        assert issubclass(types.FastAPIJsonCoder, Coder)
-
-
-@pytest.mark.unit
 class TestPydanticModelCoder:
     def test_decodes_to_pydantic_model(self) -> None:
         product = Product(
@@ -144,10 +110,9 @@ class TestPydanticModelCoder:
 
 @pytest.mark.unit
 class TestCoderExports:
-    def test_fastapi_coders_exported_from_package_root(self) -> None:
-        from redis_fastapi import FastAPIJsonCoder, pydantic_model_coder
+    def test_coders_exported_from_package_root(self) -> None:
+        from redis_fastapi import pydantic_model_coder
 
-        assert FastAPIJsonCoder is types.FastAPIJsonCoder
         assert pydantic_model_coder is types.pydantic_model_coder
 
 


### PR DESCRIPTION
  Without this feature, CacheBackend uses JsonCoder, which is just` json.dumps()` /` json.loads()`. It works for plain JSON values, but fails for common FastAPI values like Pydantic models,

 ` datetime`, `UUID`, `enums`, `Decimal` and dataclasses unless the user manually converts them.

  With this feature, users can opt into:

  - `FastAPIJsonCoder`: accepts FastAPI-compatible values by using` jsonable_encoder()` before JSON encoding.
  - `pydantic_model_coder(Model)`: validates and decodes cache hits back into Pydantic model instances.

