### PR TITLE
Add Redis-backed fixed-window rate limiting (INCREX with Lua fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /site/
 /bandit-report.json
 /coverage.xml
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Idiomatic Redis integration for FastAPI - connection management and DI-based cac
 
 - **Fluent setup** — `FastAPIRedis(app).lifespan().caching()` configures pools and caching in one chain, attaching to the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/)
 - **Dependency injection** — `cache()`, `cache_evict()`, `cache_put()` as `Depends()` factories, plus `CacheBackend` for complex invalidation and conditional logic
+- **Rate limiting** — `rate_limit()` as `Depends()` factory with INCREX and atomic Lua fallback
 - **HTTP-native caching** — [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag), [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304), [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) directives out of the box
 - **Testable** — full `dependency_overrides` support; no need for monkey-patching
 - **Pydantic-validated configuration** — fully configurable via environment variables or via an `.env` file
@@ -121,6 +122,29 @@ async def dashboard(user_id: int, cache: CacheBackendDep):
 Provides `get`/`set`/`delete`/`has`/`delete_group` with automatic JSON serialization. Use it for conditional caching, cascade invalidation, dynamic TTL, and intermediate result caching.
 
 See the [Caching Guide](docs/guide/caching.md) for detailed examples, feature comparison, and best practices.
+
+## Rate Limiting
+
+Redis-backed fixed-window rate limiting as a FastAPI dependency:
+
+```python
+from fastapi import Depends
+from redis_fastapi import FastAPIRedis, rate_limit
+
+app = FastAPI()
+FastAPIRedis(app).lifespan()
+
+@app.get("/items", dependencies=[Depends(rate_limit(limit=100, window=60))])
+async def get_items():
+    return {"ok": True}
+```
+
+Uses [`INCREX`](https://redis.io/docs/latest/commands/increx/) when available (Redis 8.8+)
+and falls back to an atomic Lua script for older versions. Supports custom key builders,
+sync endpoints, and OpenTelemetry instrumentation.
+
+See the [Rate Limiting Guide](docs/guide/rate-limiting.md) for detailed configuration,
+OTel setup, and testing patterns.
 
 ## Configuration
 

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -1,0 +1,246 @@
+# Rate Limiting
+
+fastapi-redis-sdk provides Redis-backed **fixed-window rate limiting** as a
+FastAPI dependency.  It uses [`INCREX`](https://redis.io/docs/latest/commands/increx/)
+when the Redis server supports it (Redis OSS 8.8+) and falls back to an
+atomic Lua script otherwise — all transparently.
+
+| Feature | Support |
+|---------|---------|
+| Fixed-window counter | ✅ |
+| `INCREX` (Redis 8.8+) | ✅ |
+| Lua fallback (Redis 7.4+) | ✅ |
+| One-time capability detection | ✅ |
+| Custom key builder (sync/async) | ✅ |
+| Custom key prefix | ✅ |
+| Async and sync endpoints | ✅ |
+| OpenTelemetry spans & metrics | ✅ |
+| Rate-limit response headers (`Retry-After`) | ✅ |
+
+---
+
+## 1. Basic usage
+
+```python
+from fastapi import Depends, FastAPI
+from redis_fastapi import FastAPIRedis, rate_limit
+
+app = FastAPI()
+FastAPIRedis(app).lifespan()
+
+@app.get("/items", dependencies=[Depends(rate_limit(limit=100, window=60))])
+async def get_items():
+    return {"ok": True}
+```
+
+This allows **up to 100 requests per 60-second window** per client IP + method + path.
+
+### Parameters
+
+| Argument      | Type     | Default | Description |
+|---------------|----------|---------|-------------|
+| `limit`       | `int`    | (required) | Maximum requests in the window. Must be ≥ 1. |
+| `window`      | `int`    | (required) | Window length in seconds. Must be ≥ 1. |
+| `key_builder` | `Callable` | `default_rate_limit_key_builder` | Sync or async function that returns a rate-limit key string. Receives the `Request` object. |
+| `prefix`      | `str` | `"redis:fastapi:ratelimit"` | Redis key prefix. |
+
+---
+
+## 2. How it works
+
+### Fixed-window counter
+
+- The first request creates a Redis counter with a TTL.
+- Each request increments the counter.
+- When the counter reaches `limit`, further requests are rejected with
+  `429 Too Many Requests`.
+- After the TTL expires, the counter resets and requests are allowed again.
+
+### Redis command path
+
+When the connected server supports INCREX (Redis OSS 8.8+), the dependency
+executes a single atomic command per request:
+
+```redis
+INCREX redis:fastapi:ratelimit:<key> BYINT 1 UBOUND <limit> EX <window> ENX
+```
+
+The `ENX` flag ensures the TTL is set **only when the key is created**,
+preserving fixed-window semantics.
+
+### Lua fallback
+
+When INCREX is unavailable, the library falls back to an equivalent Lua script
+that performs the same atomic increment, bound check, and TTL management.
+
+### One-time detection
+
+INCREX capability is detected on the first rate-limit request and cached in the
+application state.  Subsequent requests use the known path directly — no
+per-request fallback overhead.
+
+---
+
+## 3. Rate-limit key
+
+### Default key
+
+The default key uses the client IP, HTTP method, and URL path:
+
+```
+redis:fastapi:ratelimit:127.0.0.1:GET:api:v1:items
+```
+
+The default key builder is exported as
+`redis_fastapi.rate_limit.default_rate_limit_key_builder`.
+
+### Custom key builder
+
+Pass a `key_builder` function to scope limits differently — for example, by
+authenticated user ID:
+
+```python
+from fastapi import Request
+
+def user_key_builder(request: Request) -> str:
+    return request.headers.get("X-User-Id", "anonymous")
+
+@app.get("/profile", dependencies=[Depends(rate_limit(limit=30, window=60, key_builder=user_key_builder))])
+async def get_profile():
+    return {"user": "data"}
+```
+
+Async key builders are supported — if the function is a coroutine, it is
+awaited automatically.
+
+### Custom prefix
+
+Override the Redis key prefix if the default conflicts with other keys:
+
+```python
+Depends(rate_limit(limit=100, window=60, prefix="myapp:ratelimit"))
+```
+
+---
+
+## 4. Behaviour on block
+
+When a request exceeds the limit, the dependency raises `HTTPException` with:
+
+- **Status code:** `429 Too Many Requests`
+- **Detail:** `"Too Many Requests"`
+- **Header:** `Retry-After: <seconds>`
+
+The endpoint body is never executed for blocked requests.
+
+---
+
+## 5. Error handling
+
+If Redis is unreachable or returns an error, the rate limiter **fails open**:
+the request is allowed, the error is logged, and telemetry records
+`result="error"`.
+
+This matches the project's caching error policy — a Redis outage should not
+take down the application.
+
+---
+
+## 6. OpenTelemetry
+
+When OTel is enabled (via `FastAPIRedis(app).otel()` or
+`redis_fastapi.enable_telemetry()`), rate-limit operations emit:
+
+### Span
+
+| Name | Attributes |
+|------|------------|
+| `rate_limit.check` | `rate_limit.key`, `rate_limit.limit`, `rate_limit.window`, `rate_limit.allowed`, `rate_limit.remaining`, `rate_limit.backend` (increx or lua) |
+
+### Metric
+
+| Name | Type | Labels |
+|------|------|--------|
+| `redis_fastapi.rate_limit.requests` | Counter | `result` (allowed, blocked, error) |
+
+---
+
+## 7. Sync endpoints
+
+The rate-limit dependency is an `async def` dependency, so FastAPI handles it
+correctly before both async and sync endpoints:
+
+```python
+@app.get("/sync", dependencies=[Depends(rate_limit(limit=5, window=60))])
+def sync_endpoint():
+    return {"ok": True}
+```
+
+---
+
+## 8. Testing
+
+Use `dependency_overrides` to swap the real Redis client for a fake:
+
+```python
+import fakeredis.aioredis
+from fastapi.testclient import TestClient
+from redis_fastapi import FastAPIRedis, rate_limit, get_async_redis
+
+app = FastAPI()
+FastAPIRedis(app).lifespan()
+
+@app.get("/limited", dependencies=[Depends(rate_limit(limit=3, window=60))])
+async def limited():
+    return {"ok": True}
+
+fake = fakeredis.aioredis.FakeRedis()
+app.dependency_overrides[get_async_redis] = lambda: fake
+
+with TestClient(app) as client:
+    r1 = client.get("/limited")
+    assert r1.status_code == 200
+    r2 = client.get("/limited")
+    assert r2.status_code == 200
+    r3 = client.get("/limited")
+    assert r3.status_code == 200
+    r4 = client.get("/limited")
+    assert r4.status_code == 429
+```
+
+---
+
+## 9. Reference
+
+```python
+redis_fastapi.rate_limit(
+    limit: int,
+    window: int,
+    *,
+    key_builder: Callable[[Request], str | Awaitable[str]] | None = None,
+    prefix: str | None = None,
+) -> Depends
+```
+
+### Result object
+
+`RateLimitResult` (dataclass) is the internal result type, also exported from
+`redis_fastapi`:
+
+| Field        | Type      | Description |
+|--------------|-----------|-------------|
+| `allowed`    | `bool`    | Whether the request is allowed |
+| `current`    | `int`     | Current counter value after the request |
+| `remaining`  | `int`     | Requests remaining in the window |
+| `retry_after` | `int`    | Seconds until the window resets |
+| `backend`    | `str`     | `"increx"` or `"lua"` |
+
+### Default key builder
+
+```python
+redis_fastapi.rate_limit.default_rate_limit_key_builder(
+    request: Request,
+) -> str
+```
+
+Returns `"{client_ip}:{method}:{path}"`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ caching with automatic key consistency.
 - **Fluent setup** — `FastAPIRedis(app).lifespan().caching()` configures pools and caching in one chain, attaching to the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/)
 - **Dependency injection** — `cache()`, `cache_evict()`, `cache_put()` as `Depends()` factories, plus `CacheBackend` for complex invalidation and conditional logic
 - **HTTP-native caching** — [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag), [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304), [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) directives out of the box
+- **Rate limiting** — `rate_limit()` as `Depends()` factory with INCREX and atomic Lua fallback
 - **Testable** — full `dependency_overrides` support; no need for monkey-patching
 - **Pydantic-validated configuration** — fully configurable via environment variables or via an `.env` file
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - User Guide:
     - Architecture: guide/architecture.md
     - Caching: guide/caching.md
+    - Rate Limiting: guide/rate-limiting.md
     - Configuration: guide/configuration.md
     - Benchmarks: guide/benchmarks.md
   - API Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "coverage[toml]>=7.10.1",
     "fakeredis>=2.35.0",
     "httpx>=0.23.0,<1.0.0",
+    "lupa>=2.8",
     "pytest>=9.0.0",
     "pytest-asyncio>=1.1.0",
     "pytest-cov>=6.2.1",

--- a/src/redis_fastapi/__init__.py
+++ b/src/redis_fastapi/__init__.py
@@ -21,6 +21,11 @@ from redis_fastapi.deps import (
     get_sync_cache_backend,
 )
 from redis_fastapi.lifespan import redis_lifespan
+from redis_fastapi.rate_limit import (
+    RateLimitResult,
+    default_rate_limit_key_builder,
+    rate_limit,
+)
 from redis_fastapi.setup import FastAPIRedis
 from redis_fastapi.telemetry import disable_telemetry, enable_telemetry
 from redis_fastapi.types import Coder, JsonCoder, KeyBuilder
@@ -42,11 +47,14 @@ __all__ = [
     "cache_evict",
     "cache_put",
     "default_key_builder",
+    "default_rate_limit_key_builder",
     "disable_telemetry",
     "enable_telemetry",
     "get_async_redis",
     "get_cache_backend",
     "get_settings",
     "get_sync_cache_backend",
+    "RateLimitResult",
+    "rate_limit",
     "redis_lifespan",
 ]

--- a/src/redis_fastapi/deps.py
+++ b/src/redis_fastapi/deps.py
@@ -6,6 +6,8 @@ import logging
 from typing import TYPE_CHECKING, Annotated, TypeAlias
 
 if TYPE_CHECKING:
+    from redis.commands.core import AsyncScript
+
     from redis_fastapi.cache_backend import CacheBackend, SyncCacheBackend
 
 from fastapi import Depends, FastAPI, Request
@@ -33,6 +35,11 @@ class _PoolState:
     async_pool: AsyncConnectionPool | None = None
     async_cluster: AsyncRedisCluster | None = None
     _async_client: AsyncRedis | None = None
+
+    # Rate-limit INCREX capability state (unknown/supported/unsupported)
+    increx_supported: str = "unknown"
+    # Cached redis-py AsyncScript object for the Lua rate-limit fallback
+    _rate_limit_script: AsyncScript | None = None
 
     # -- pool / cluster builders (static) -----------------------------------
 
@@ -92,6 +99,8 @@ class _PoolState:
     def clear(self) -> None:
         """Reset cached clients (called during lifespan shutdown)."""
         self._async_client = None
+        self.increx_supported = "unknown"
+        self._rate_limit_script = None
 
 
 def _get_pool_state(app: FastAPI) -> _PoolState:

--- a/src/redis_fastapi/deps.py
+++ b/src/redis_fastapi/deps.py
@@ -6,8 +6,6 @@ import logging
 from typing import TYPE_CHECKING, Annotated, TypeAlias
 
 if TYPE_CHECKING:
-    from redis.commands.core import AsyncScript
-
     from redis_fastapi.cache_backend import CacheBackend, SyncCacheBackend
 
 from fastapi import Depends, FastAPI, Request
@@ -38,8 +36,6 @@ class _PoolState:
 
     # Rate-limit INCREX capability state (unknown/supported/unsupported)
     increx_supported: str = "unknown"
-    # Cached redis-py AsyncScript object for the Lua rate-limit fallback
-    _rate_limit_script: AsyncScript | None = None
 
     # -- pool / cluster builders (static) -----------------------------------
 
@@ -100,7 +96,6 @@ class _PoolState:
         """Reset cached clients (called during lifespan shutdown)."""
         self._async_client = None
         self.increx_supported = "unknown"
-        self._rate_limit_script = None
 
 
 def _get_pool_state(app: FastAPI) -> _PoolState:

--- a/src/redis_fastapi/rate_limit.py
+++ b/src/redis_fastapi/rate_limit.py
@@ -19,10 +19,9 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from inspect import isawaitable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 from fastapi import Depends, HTTPException, Request
-from redis.asyncio import Redis as AsyncRedis_
 from redis.exceptions import RedisError, ResponseError
 from starlette.status import HTTP_429_TOO_MANY_REQUESTS
 
@@ -85,6 +84,26 @@ async def _check_increx_supported(redis: AsyncClient) -> bool:
         return False
 
 
+async def _run_lua(
+    redis: AsyncClient,
+    key: str,
+    limit: int,
+    window: int,
+) -> tuple[int, int, int]:
+    result = await redis.execute_command(
+        "EVAL",
+        _RATE_LIMIT_LUA,
+        1,
+        key,
+        str(limit),
+        str(window),
+    )
+    if result is None:
+        raise RedisError("Lua rate-limit script returned None")
+    raw_current, raw_actual_incr, raw_ttl = result
+    return int(raw_current), int(raw_actual_incr), int(raw_ttl)
+
+
 async def _check_rate_limit(
     redis: AsyncClient,
     key: str,
@@ -129,19 +148,7 @@ async def _check_rate_limit(
         except ResponseError:
             pool_state.increx_supported = "unsupported"
 
-    if pool_state._rate_limit_script is None:
-        pool_state._rate_limit_script = cast(AsyncRedis_, redis).register_script(
-            _RATE_LIMIT_LUA
-        )
-
-    raw_current, raw_actual_incr, raw_ttl = await pool_state._rate_limit_script(
-        keys=[key],
-        args=[str(limit), str(window)],
-    )
-    current_val = int(raw_current)
-    actual_incr = int(raw_actual_incr)
-    ttl = int(raw_ttl)
-
+    current_val, actual_incr, ttl = await _run_lua(redis, key, limit, window)
     allowed = actual_incr == 1
     remaining = max(0, limit - current_val)
     retry_after = max(0, ttl) if ttl >= 0 else window
@@ -160,7 +167,7 @@ def rate_limit(
     *,
     key_builder: RateLimitKeyBuilder | None = None,
     prefix: str | None = None,
-) -> Any:
+) -> Callable[..., Awaitable[None]]:
     if limit < 1:
         raise ValueError("limit must be >= 1")
     if window < 1:

--- a/src/redis_fastapi/rate_limit.py
+++ b/src/redis_fastapi/rate_limit.py
@@ -1,0 +1,211 @@
+"""Redis-backed fixed-window rate limiting for FastAPI endpoints.
+
+Usage::
+
+    from fastapi import Depends, FastAPI
+    from redis_fastapi import FastAPIRedis, rate_limit
+
+    app = FastAPI()
+    FastAPIRedis(app).lifespan()
+
+    @app.get("/items", dependencies=[Depends(rate_limit(limit=100, window=60))])
+    async def get_items():
+        return {"ok": True}
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Any, cast
+
+from fastapi import Depends, HTTPException, Request
+from redis.asyncio import Redis as AsyncRedis_
+from redis.exceptions import RedisError, ResponseError
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+from redis_fastapi.deps import _get_pool_state, get_async_redis
+from redis_fastapi.telemetry import rate_limit_span, record_rate_limit_request
+
+if TYPE_CHECKING:
+    from redis_fastapi.deps import AsyncClient, _PoolState
+
+logger = logging.getLogger(__name__)
+
+# Lua script for atomic increment-bound-expiry fallback.
+# Returns {current_value, actual_incr (0|1), retry_after_seconds}.
+_RATE_LIMIT_LUA = """
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+local limit = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+if current >= limit then
+    local ttl = redis.call("TTL", KEYS[1])
+    return {current, 0, (ttl >= 0 and ttl or window)}
+end
+
+local next_value = redis.call("INCR", KEYS[1])
+
+if next_value == 1 or redis.call("TTL", KEYS[1]) < 0 then
+    redis.call("EXPIRE", KEYS[1], window)
+end
+
+local ttl = redis.call("TTL", KEYS[1])
+return {next_value, 1, (ttl >= 0 and ttl or window)}
+"""
+
+DEFAULT_RATE_LIMIT_PREFIX = "redis:fastapi:ratelimit"
+
+RateLimitKeyBuilder = Callable[..., str | Awaitable[str]]
+
+
+def default_rate_limit_key_builder(request: Request) -> str:
+    client = request.client.host if request.client else "unknown"
+    path = request.url.path.strip("/").replace("/", ":")
+    return f"{client}:{request.method}:{path}"
+
+
+@dataclass(frozen=True)
+class RateLimitResult:
+    allowed: bool
+    current: int
+    remaining: int
+    retry_after: int
+    backend: str
+
+
+async def _check_increx_supported(redis: AsyncClient) -> bool:
+    try:
+        await redis.execute_command("INCREX", "__ratelimit_probe__", "BYINT", 0)
+        await redis.delete("__ratelimit_probe__")
+        return True
+    except ResponseError:
+        return False
+
+
+async def _check_rate_limit(
+    redis: AsyncClient,
+    key: str,
+    limit: int,
+    window: int,
+    pool_state: _PoolState,
+) -> RateLimitResult:
+    if pool_state.increx_supported == "unknown":
+        pool_state.increx_supported = (
+            "supported" if await _check_increx_supported(redis) else "unsupported"
+        )
+
+    if pool_state.increx_supported == "supported":
+        try:
+            increx_result = await redis.execute_command(
+                "INCREX",
+                key,
+                "BYINT",
+                1,
+                "UBOUND",
+                limit,
+                "EX",
+                window,
+                "ENX",
+            )
+            if increx_result is None:
+                raise RedisError("INCREX returned None")
+            raw_new_value, raw_actual_incr = increx_result
+            new_value = int(raw_new_value)
+            actual_incr = int(raw_actual_incr)
+            allowed = actual_incr == 1
+            remaining = max(0, limit - new_value)
+            ttl = await redis.ttl(key)
+            retry_after = max(0, ttl) if ttl >= 0 else window
+            return RateLimitResult(
+                allowed=allowed,
+                current=new_value,
+                remaining=remaining,
+                retry_after=retry_after,
+                backend="increx",
+            )
+        except ResponseError:
+            pool_state.increx_supported = "unsupported"
+
+    if pool_state._rate_limit_script is None:
+        pool_state._rate_limit_script = cast(AsyncRedis_, redis).register_script(
+            _RATE_LIMIT_LUA
+        )
+
+    raw_current, raw_actual_incr, raw_ttl = await pool_state._rate_limit_script(
+        keys=[key],
+        args=[str(limit), str(window)],
+    )
+    current_val = int(raw_current)
+    actual_incr = int(raw_actual_incr)
+    ttl = int(raw_ttl)
+
+    allowed = actual_incr == 1
+    remaining = max(0, limit - current_val)
+    retry_after = max(0, ttl) if ttl >= 0 else window
+    return RateLimitResult(
+        allowed=allowed,
+        current=current_val,
+        remaining=remaining,
+        retry_after=retry_after,
+        backend="lua",
+    )
+
+
+def rate_limit(
+    limit: int,
+    window: int,
+    *,
+    key_builder: RateLimitKeyBuilder | None = None,
+    prefix: str | None = None,
+) -> Any:
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    if window < 1:
+        raise ValueError("window must be >= 1")
+
+    builder = key_builder or default_rate_limit_key_builder
+    key_prefix = prefix or DEFAULT_RATE_LIMIT_PREFIX
+
+    async def _dependency(
+        request: Request,
+        redis: AsyncClient = Depends(get_async_redis),
+    ) -> None:
+        pool_state = _get_pool_state(request.app)
+
+        raw_key = builder(request)
+        if isawaitable(raw_key):
+            raw_key = await raw_key
+        key = f"{key_prefix}:{raw_key}"
+
+        try:
+            result = await _check_rate_limit(redis, key, limit, window, pool_state)
+        except RedisError:
+            logger.warning(
+                "Redis error during rate limit check, allowing request", exc_info=True
+            )
+            return
+
+        span_attrs = {
+            "rate_limit.key": key,
+            "rate_limit.limit": limit,
+            "rate_limit.window": window,
+            "rate_limit.allowed": result.allowed,
+            "rate_limit.remaining": result.remaining,
+            "rate_limit.backend": result.backend,
+        }
+        with rate_limit_span("rate_limit.check", attributes=span_attrs):
+            record_rate_limit_request(
+                result="allowed" if result.allowed else "blocked",
+            )
+
+        if not result.allowed:
+            raise HTTPException(
+                status_code=HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too Many Requests",
+                headers={"Retry-After": str(result.retry_after)},
+            )
+
+    return _dependency

--- a/src/redis_fastapi/telemetry.py
+++ b/src/redis_fastapi/telemetry.py
@@ -20,8 +20,12 @@ import contextlib
 import dataclasses
 import logging
 import time
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Generator, Iterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from opentelemetry.metrics import Counter
+    from opentelemetry.trace import Span
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +51,9 @@ class _OTelState:
     cache_evictions: Any = None
     cache_writes: Any = None
     cache_latency: Any = None
+
+    # Rate-limit metric instruments
+    rate_limit_requests: Counter | None = None
 
 
 _state = _OTelState()
@@ -105,6 +112,12 @@ def enable_telemetry() -> None:
         name="redis_fastapi.cache.latency",
         description="Cache operation duration",
         unit="s",
+    )
+
+    _state.rate_limit_requests = _state.meter.create_counter(
+        name="redis_fastapi.rate_limit.requests",
+        description="Total rate limit checks",
+        unit="1",
     )
 
     _state.enabled = True
@@ -221,6 +234,43 @@ def record_cache_latency(
         )
     except Exception:
         logger.debug("Error recording cache latency metric", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit helpers
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def rate_limit_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Generator[Span | None, None, None]:
+    """Create a span for a rate-limit operation.
+
+    No-op context manager when OTel is disabled or not installed.
+    """
+    if not _state.enabled or _state.tracer is None:
+        yield None
+        return
+    with _state.tracer.start_as_current_span(
+        name,
+        attributes=attributes or {},
+    ) as span:
+        yield span
+
+
+def record_rate_limit_request(
+    *,
+    result: str,
+) -> None:
+    """Record a rate-limit check result (allowed / blocked / error)."""
+    if not _state.enabled or _state.rate_limit_requests is None:
+        return
+    try:
+        _state.rate_limit_requests.add(1, {"result": result})
+    except Exception:
+        logger.debug("Error recording rate limit request metric", exc_info=True)
 
 
 @contextlib.contextmanager

--- a/tests/integration/test_rate_limit.py
+++ b/tests/integration/test_rate_limit.py
@@ -1,0 +1,168 @@
+"""Integration tests for Redis-backed rate limiting.
+
+Tests the ``rate_limit()`` dependency through a full request -> Redis -> response
+cycle against a real Redis instance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+import redis as sync_redis
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from redis_fastapi.rate_limit import rate_limit
+from redis_fastapi.setup import FastAPIRedis
+from tests.conftest import requires_redis
+
+_call_count: int = 0
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    FastAPIRedis(app).lifespan()
+
+    @app.get("/limited", dependencies=[Depends(rate_limit(limit=3, window=60))])
+    async def limited_endpoint() -> dict:
+        global _call_count
+        _call_count += 1
+        return {"value": _call_count}
+
+    return app
+
+
+@pytest.fixture()
+def integ_client(
+    real_redis: sync_redis.Redis,
+) -> Generator[TestClient, None, None]:
+    global _call_count
+    _call_count = 0
+    app = _build_app()
+    with TestClient(app) as c:
+        yield c
+    real_redis.flushdb()
+
+
+@requires_redis
+@pytest.mark.integration
+class TestRateLimitIntegration:
+    def test_requests_under_limit_succeed(self, integ_client: TestClient) -> None:
+        r1 = integ_client.get("/limited")
+        assert r1.status_code == 200
+        assert r1.json()["value"] == 1
+
+        r2 = integ_client.get("/limited")
+        assert r2.status_code == 200
+        assert r2.json()["value"] == 2
+
+        r3 = integ_client.get("/limited")
+        assert r3.status_code == 200
+        assert r3.json()["value"] == 3
+
+    def test_request_over_limit_returns_429(self, integ_client: TestClient) -> None:
+        for _ in range(3):
+            integ_client.get("/limited")
+
+        r4 = integ_client.get("/limited")
+        assert r4.status_code == 429
+        assert "Retry-After" in r4.headers
+
+    def test_retry_after_header_present(self, integ_client: TestClient) -> None:
+        for _ in range(3):
+            integ_client.get("/limited")
+
+        r = integ_client.get("/limited")
+        retry_after = int(r.headers["Retry-After"])
+        assert retry_after > 0
+
+    def test_different_routes_have_independent_counters(
+        self, integ_client: TestClient, real_redis: sync_redis.Redis
+    ) -> None:
+        app = FastAPI()
+        FastAPIRedis(app).lifespan()
+
+        @app.get("/a", dependencies=[Depends(rate_limit(limit=1, window=60))])
+        async def a() -> dict:
+            return {"ok": True}
+
+        @app.get("/b", dependencies=[Depends(rate_limit(limit=1, window=60))])
+        async def b() -> dict:
+            return {"ok": True}
+
+        with TestClient(app) as c:
+            assert c.get("/a").status_code == 200
+            assert c.get("/b").status_code == 200
+            assert c.get("/a").status_code == 429
+            assert c.get("/b").status_code == 429
+
+        real_redis.flushdb()
+
+    def test_sync_endpoint_supported(self, real_redis: sync_redis.Redis) -> None:
+        app = FastAPI()
+        FastAPIRedis(app).lifespan()
+
+        @app.get("/sync", dependencies=[Depends(rate_limit(limit=5, window=60))])
+        def sync_endpoint() -> dict:
+            return {"ok": True}
+
+        with TestClient(app) as c:
+            for _ in range(5):
+                r = c.get("/sync")
+                assert r.status_code == 200
+
+            r6 = c.get("/sync")
+            assert r6.status_code == 429
+
+        real_redis.flushdb()
+
+    def test_window_expiry_allows_again(
+        self, integ_client: TestClient, real_redis: sync_redis.Redis
+    ) -> None:
+        for _ in range(3):
+            integ_client.get("/limited")
+
+        r4 = integ_client.get("/limited")
+        assert r4.status_code == 429
+
+        real_redis.flushall()
+
+        r5 = integ_client.get("/limited")
+        assert r5.status_code == 200
+
+    def test_custom_key_builder_separates_buckets(
+        self, real_redis: sync_redis.Redis
+    ) -> None:
+        app = FastAPI()
+        FastAPIRedis(app).lifespan()
+
+        def user_key_builder(request):
+            return request.headers.get("X-User-Id", "default")
+
+        @app.get(
+            "/user-limited",
+            dependencies=[
+                Depends(
+                    rate_limit(
+                        limit=1,
+                        window=60,
+                        key_builder=user_key_builder,
+                    )
+                )
+            ],
+        )
+        async def user_limited() -> dict:
+            return {"ok": True}
+
+        with TestClient(app) as c:
+            r1 = c.get("/user-limited", headers={"X-User-Id": "alice"})
+            assert r1.status_code == 200
+
+            r2 = c.get("/user-limited", headers={"X-User-Id": "bob"})
+            assert r2.status_code == 200
+
+            r3 = c.get("/user-limited", headers={"X-User-Id": "alice"})
+            assert r3.status_code == 429
+
+        real_redis.flushdb()

--- a/tests/unit/test_otel_rate_limit.py
+++ b/tests/unit/test_otel_rate_limit.py
@@ -1,0 +1,195 @@
+"""Tests: OTel spans and metrics emitted during rate-limit checks.
+
+Uses OTel in-memory exporters to verify spans/metrics without a real collector.
+"""
+
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+import redis_fastapi.telemetry as tel
+from redis_fastapi.deps import get_async_redis
+from redis_fastapi.rate_limit import rate_limit
+
+# ---------------------------------------------------------------------------
+# In-memory span exporter
+# ---------------------------------------------------------------------------
+
+
+class InMemorySpanExporter(SpanExporter):
+    """Collects finished spans in memory for test assertions."""
+
+    def __init__(self) -> None:
+        self._spans: list = []
+
+    def export(self, spans):  # type: ignore[override]
+        self._spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def get_finished_spans(self) -> list:
+        return list(self._spans)
+
+    def clear(self) -> None:
+        self._spans.clear()
+
+    def shutdown(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# OTel test fixtures - module-scoped providers, per-test reset
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _otel_cleanup(request: pytest.FixtureRequest) -> None:
+    """Reset telemetry module state before each test."""
+    orig = tel._state
+    tel.disable_telemetry()
+
+    yield
+
+    tel._state = orig
+
+
+@pytest.fixture()
+def span_exporter() -> InMemorySpanExporter:
+    return InMemorySpanExporter()
+
+
+@pytest.fixture()
+def metric_reader() -> InMemoryMetricReader:
+    return InMemoryMetricReader()
+
+
+def _make_otel_app(
+    fake: fakeredis.aioredis.FakeRedis,
+) -> tuple[FastAPI, list[int]]:
+    app = FastAPI()
+    counts: list[int] = [0]
+
+    @app.get("/limited", dependencies=[Depends(rate_limit(limit=3, window=60))])
+    async def limited_endpoint() -> dict:
+        counts[0] += 1
+        return {"value": counts[0]}
+
+    async def _fake() -> fakeredis.aioredis.FakeRedis:
+        return fake
+
+    app.dependency_overrides[get_async_redis] = _fake
+    return app, counts
+
+
+def _setup_test_otel(
+    span_exporter: InMemorySpanExporter,
+    metric_reader: InMemoryMetricReader,
+) -> None:
+    """Configure OTel for a single test using dedicated in-memory exporters.
+
+    Bypasses the global tracer / meter provider so that different test
+    files can each use their own exporters without conflicting.
+    """
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = tracer_provider.get_tracer(tel.TRACER_NAME)
+
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter = meter_provider.get_meter(tel.METER_NAME)
+
+    tel._state.tracer = tracer
+    tel._state.meter = meter
+    tel._state.enabled = True
+    tel._state.rate_limit_requests = meter.create_counter(
+        name="redis_fastapi.rate_limit.requests",
+        description="Total rate limit checks",
+        unit="1",
+    )
+
+
+# ===================================================================
+# Rate-limit spans
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRateLimitSpans:
+    def test_allowed_request_emits_rate_limit_span(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+        span_exporter: InMemorySpanExporter,
+    ) -> None:
+        _setup_test_otel(span_exporter, InMemoryMetricReader())
+        app, _ = _make_otel_app(fake_async_redis)
+        with TestClient(app) as c:
+            c.get("/limited")
+
+        spans = span_exporter.get_finished_spans()
+        rate_spans = [s for s in spans if s.name == "rate_limit.check"]
+        assert len(rate_spans) >= 1
+        span = rate_spans[0]
+        assert span.attributes.get("rate_limit.allowed") is True
+        assert span.attributes.get("rate_limit.remaining") is not None
+        assert span.attributes.get("rate_limit.backend") is not None
+
+    def test_blocked_request_emits_rate_limit_span(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+        span_exporter: InMemorySpanExporter,
+    ) -> None:
+        _setup_test_otel(span_exporter, InMemoryMetricReader())
+        app, _ = _make_otel_app(fake_async_redis)
+        with TestClient(app) as c:
+            c.get("/limited")
+            c.get("/limited")
+            c.get("/limited")
+            span_exporter.clear()
+            resp = c.get("/limited")
+
+        assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+        spans = span_exporter.get_finished_spans()
+        rate_spans = [s for s in spans if s.name == "rate_limit.check"]
+        assert len(rate_spans) >= 1
+        span = rate_spans[0]
+        assert span.attributes.get("rate_limit.allowed") is False
+
+
+# ===================================================================
+# Rate-limit metrics
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRateLimitMetrics:
+    def test_rate_limit_requests_metric_recorded(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+        metric_reader: InMemoryMetricReader,
+    ) -> None:
+        _setup_test_otel(InMemorySpanExporter(), metric_reader)
+        app, _ = _make_otel_app(fake_async_redis)
+        with TestClient(app) as c:
+            c.get("/limited")  # allowed
+            c.get("/limited")  # allowed
+            c.get("/limited")  # allowed
+
+        data = metric_reader.get_metrics_data()
+        metrics_by_name = {}
+        for resource_metrics in data.resource_metrics:
+            for scope_metrics in resource_metrics.scope_metrics:
+                for metric in scope_metrics.metrics:
+                    metrics_by_name[metric.name] = metric
+
+        assert "redis_fastapi.rate_limit.requests" in metrics_by_name

--- a/tests/unit/test_rate_limit.py
+++ b/tests/unit/test_rate_limit.py
@@ -1,0 +1,490 @@
+"""Tests for Redis-backed rate limiting: rate_limit() dependency.
+
+Uses fakeredis for all Redis operations. fakeredis does not support
+INCREX, so the Lua fallback path is exercised in every test that uses
+a real fake Redis client. An explicit INCREX test mocks the probe to
+verify the INCREX code path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import fakeredis.aioredis
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from redis.exceptions import ConnectionError as RedisConnectionError
+from starlette.status import HTTP_429_TOO_MANY_REQUESTS
+
+from redis_fastapi.deps import _get_pool_state, get_async_redis
+from redis_fastapi.rate_limit import (
+    DEFAULT_RATE_LIMIT_PREFIX,
+    rate_limit,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers: create test apps with rate-limited endpoints
+# ---------------------------------------------------------------------------
+
+
+def _make_app(
+    fake: fakeredis.aioredis.FakeRedis,
+    limit: int = 5,
+    window: int = 60,
+    **kwargs: object,
+) -> tuple[FastAPI, list[int]]:
+    app = FastAPI()
+    counts: list[int] = [0]
+
+    @app.get(
+        "/limited",
+        dependencies=[Depends(rate_limit(limit=limit, window=window, **kwargs))],
+    )
+    async def limited_endpoint() -> dict:
+        counts[0] += 1
+        return {"value": counts[0]}
+
+    async def _fake() -> fakeredis.aioredis.FakeRedis:
+        return fake
+
+    app.dependency_overrides[get_async_redis] = _fake
+    return app, counts
+
+
+# ===================================================================
+# Basic allow / block
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRateLimitAllowBlock:
+    def test_requests_under_limit_are_allowed(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, counts = _make_app(fake_async_redis, limit=3, window=60)
+        with TestClient(app) as c:
+            for _ in range(3):
+                resp = c.get("/limited")
+                assert resp.status_code == 200, resp.text
+                assert resp.json()["value"] == counts[0]
+
+        assert counts[0] == 3
+
+    def test_request_over_limit_returns_429(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, counts = _make_app(fake_async_redis, limit=3, window=60)
+        with TestClient(app) as c:
+            for _ in range(3):
+                resp = c.get("/limited")
+                assert resp.status_code == 200
+
+            resp = c.get("/limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+        assert counts[0] == 3
+
+    def test_retry_after_header_present(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, _ = _make_app(fake_async_redis, limit=2, window=60)
+        with TestClient(app) as c:
+            c.get("/limited")
+            c.get("/limited")
+            resp = c.get("/limited")
+
+        assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+        assert "retry-after" in resp.headers
+
+    def test_endpoint_not_called_when_limited(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, counts = _make_app(fake_async_redis, limit=1, window=60)
+        with TestClient(app) as c:
+            resp1 = c.get("/limited")
+            assert resp1.status_code == 200
+            assert counts[0] == 1
+
+            resp2 = c.get("/limited")
+            assert resp2.status_code == HTTP_429_TOO_MANY_REQUESTS
+            assert counts[0] == 1
+
+    def test_window_expiry_allows_again(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, counts = _make_app(fake_async_redis, limit=2, window=1)
+        with TestClient(app) as c:
+            c.get("/limited")
+            c.get("/limited")
+            resp = c.get("/limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+        import time as _time
+
+        _time.sleep(1.1)
+
+        with TestClient(app) as c:
+            resp = c.get("/limited")
+            assert resp.status_code == 200
+            assert resp.json()["value"] == counts[0]
+
+    def test_different_routes_have_independent_counters(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app = FastAPI()
+        call_count: list[int] = [0]
+
+        @app.get("/a", dependencies=[Depends(rate_limit(limit=1, window=60))])
+        async def a_endpoint() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        @app.get("/b", dependencies=[Depends(rate_limit(limit=1, window=60))])
+        async def b_endpoint() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        with TestClient(app) as c:
+            resp = c.get("/a")
+            assert resp.status_code == 200
+            resp = c.get("/b")
+            assert resp.status_code == 200
+            resp = c.get("/a")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+            resp = c.get("/b")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+
+# ===================================================================
+# Value errors
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRateLimitValidation:
+    def test_invalid_limit_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="limit must be >= 1"):
+            rate_limit(limit=0, window=60)  # type: ignore[arg-type]
+
+    def test_invalid_window_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="window must be >= 1"):
+            rate_limit(limit=10, window=0)  # type: ignore[arg-type]
+
+
+# ===================================================================
+# Custom key builder
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestCustomKeyBuilder:
+    def test_custom_key_builder_separates_buckets(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app = FastAPI()
+        call_count: list[int] = [0]
+
+        @app.get(
+            "/a",
+            dependencies=[
+                Depends(
+                    rate_limit(limit=2, window=60, key_builder=lambda r: "bucket-a")
+                )
+            ],
+        )
+        async def endpoint_a() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        @app.get(
+            "/b",
+            dependencies=[
+                Depends(
+                    rate_limit(limit=2, window=60, key_builder=lambda r: "bucket-b")
+                )
+            ],
+        )
+        async def endpoint_b() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        with TestClient(app) as c:
+            c.get("/a")
+            c.get("/a")
+            resp = c.get("/a")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+            resp = c.get("/b")
+            assert resp.status_code == 200
+
+    def test_async_key_builder_supported(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app = FastAPI()
+        call_count: list[int] = [0]
+
+        async def async_builder(request: object) -> str:
+            return "async-bucket"
+
+        @app.get(
+            "/limited",
+            dependencies=[
+                Depends(rate_limit(limit=1, window=60, key_builder=async_builder))
+            ],
+        )
+        async def limited_endpoint() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        with TestClient(app) as c:
+            resp = c.get("/limited")
+            assert resp.status_code == 200
+            resp = c.get("/limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+
+# ===================================================================
+# Sync endpoint support
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestSyncEndpoint:
+    def test_sync_endpoint_supported(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app = FastAPI()
+        call_count: list[int] = [0]
+
+        @app.get(
+            "/sync-limited", dependencies=[Depends(rate_limit(limit=2, window=60))]
+        )
+        def sync_endpoint() -> dict:
+            call_count[0] += 1
+            return {"value": call_count[0]}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        with TestClient(app) as c:
+            c.get("/sync-limited")
+            c.get("/sync-limited")
+            resp = c.get("/sync-limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+        assert call_count[0] == 2
+
+
+# ===================================================================
+# Lua fallback (INCREX unsupported)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestLuaFallback:
+    def test_lua_fallback_used_when_increx_unsupported(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        """fakeredis does not support INCREX, so Lua fallback is used automatically."""
+        app, _ = _make_app(fake_async_redis, limit=3, window=60)
+        pool_state = _get_pool_state(app)
+        assert pool_state.increx_supported == "unknown"
+
+        with TestClient(app) as c:
+            for _ in range(3):
+                resp = c.get("/limited")
+                assert resp.status_code == 200
+
+            resp = c.get("/limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+        assert pool_state.increx_supported == "unsupported"
+
+    def test_increx_unsupported_detected_once(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        """The INCREX probe executes exactly once — on the first request."""
+        app, _ = _make_app(fake_async_redis, limit=5, window=60)
+        pool_state = _get_pool_state(app)
+
+        with patch.object(
+            fake_async_redis, "execute_command", wraps=fake_async_redis.execute_command
+        ) as mock_exec:
+            with TestClient(app) as c:
+                c.get("/limited")
+
+            increx_calls = [
+                call for call in mock_exec.call_args_list if call[0][0] == "INCREX"
+            ]
+            assert len(increx_calls) == 1
+
+        pool_state.increx_supported = "unsupported"
+
+        with patch.object(
+            fake_async_redis, "execute_command", wraps=fake_async_redis.execute_command
+        ) as mock_exec:
+            with TestClient(app) as c:
+                c.get("/limited")
+
+            increx_calls = [
+                call for call in mock_exec.call_args_list if call[0][0] == "INCREX"
+            ]
+            assert len(increx_calls) == 0
+
+
+# ===================================================================
+# INCREX supported path (mocked)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestIncrexPath:
+    def test_increx_supported_path(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        """When INCREX is supported, the INCREX code path is exercised."""
+        app, _ = _make_app(fake_async_redis, limit=3, window=60)
+        pool_state = _get_pool_state(app)
+
+        original_exec = fake_async_redis.execute_command
+
+        async def fake_increx(command: str, *args: object, **kwargs: object) -> object:
+            if command == "INCREX":
+                if args and str(args[0]) == "__ratelimit_probe__":
+                    return [0, 0]
+                key = str(args[0])
+                existing = await fake_async_redis.get(key)
+                current = int(existing) if existing else 0
+                # args: [key, "BYINT", 1, "UBOUND", limit, "EX", window, "ENX"]
+                limit_val = int(args[4])  # type: ignore[arg-type]
+                if current >= limit_val:
+                    return [current, 0]
+                new_val = current + 1
+                await fake_async_redis.set(key, str(new_val))
+                window_secs = int(args[6])  # type: ignore[arg-type]
+                await fake_async_redis.expire(key, window_secs)
+                return [new_val, 1]
+            return await original_exec(command, *args, **kwargs)
+
+        fake_async_redis.execute_command = fake_increx  # type: ignore[method-assign]
+
+        with TestClient(app) as c:
+            resp = c.get("/limited")
+            assert resp.status_code == 200
+            assert pool_state.increx_supported == "supported"
+
+            c.get("/limited")
+            c.get("/limited")
+            resp = c.get("/limited")
+            assert resp.status_code == HTTP_429_TOO_MANY_REQUESTS
+
+
+# ===================================================================
+# Redis error policy (fail open)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRedisErrorPolicy:
+    def test_redis_error_fails_open(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        """When Redis raises an error, the request succeeds (fail open)."""
+        app = FastAPI()
+
+        @app.get("/limited", dependencies=[Depends(rate_limit(limit=5, window=60))])
+        async def limited_endpoint() -> dict:
+            return {"ok": True}
+
+        async def broken_redis() -> AsyncMock:
+            client = AsyncMock(spec=fake_async_redis)
+            client.execute_command = AsyncMock(
+                side_effect=RedisConnectionError("Redis down")
+            )
+            return client
+
+        app.dependency_overrides[get_async_redis] = broken_redis
+
+        with TestClient(app) as c:
+            resp = c.get("/limited")
+            assert resp.status_code == 200
+
+
+# ===================================================================
+# Default key builder
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestDefaultKeyBuilder:
+    async def test_default_key_prefix(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app, _ = _make_app(fake_async_redis, limit=5, window=60)
+        with TestClient(app) as c:
+            c.get("/limited")
+
+        keys = await fake_async_redis.keys(f"{DEFAULT_RATE_LIMIT_PREFIX}:*")
+        assert len(keys) >= 1
+        key = keys[0].decode() if isinstance(keys[0], bytes) else str(keys[0])
+        assert key.startswith(DEFAULT_RATE_LIMIT_PREFIX)
+        assert "GET" in key
+        assert "limited" in key
+
+    async def test_custom_prefix_overrides_default(
+        self,
+        fake_async_redis: fakeredis.aioredis.FakeRedis,
+    ) -> None:
+        app = FastAPI()
+
+        @app.get(
+            "/limited",
+            dependencies=[
+                Depends(rate_limit(limit=5, window=60, prefix="myapp:ratelimit"))
+            ],
+        )
+        async def limited_endpoint() -> dict:
+            return {"ok": True}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        with TestClient(app) as c:
+            c.get("/limited")
+
+        keys = await fake_async_redis.keys("myapp:ratelimit:*")
+        assert len(keys) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -724,6 +724,98 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi-redis-sdk"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi", extra = ["standard"] },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "redis" },
+]
+
+[package.optional-dependencies]
+otel = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "anyio", extra = ["trio"] },
+    { name = "bandit", extra = ["toml"] },
+    { name = "coverage", extra = ["toml"] },
+    { name = "fakeredis" },
+    { name = "httpx" },
+    { name = "lupa" },
+    { name = "mypy" },
+    { name = "nox" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
+    { name = "safety" },
+    { name = "twine" },
+]
+test = [
+    { name = "anyio", extra = ["trio"] },
+    { name = "coverage", extra = ["toml"] },
+    { name = "fakeredis" },
+    { name = "httpx" },
+    { name = "lupa" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "pytest-timeout" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20" },
+    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20" },
+    { name = "pydantic", specifier = ">=2.12.5" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "redis", specifier = ">=6.0.0,<7.3.0" },
+]
+provides-extras = ["otel"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "anyio", extras = ["trio"], specifier = ">=3.2.1,<5.0.0" },
+    { name = "bandit", extras = ["toml"], specifier = ">=1.8.6" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10.1" },
+    { name = "fakeredis", specifier = ">=2.35.0" },
+    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
+    { name = "lupa", specifier = ">=2.8" },
+    { name = "mypy", specifier = ">=1.17.0" },
+    { name = "nox", specifier = ">=2026.4.10" },
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.12.5" },
+    { name = "safety", specifier = ">=3.6.0" },
+    { name = "twine", specifier = ">=4.0" },
+]
+test = [
+    { name = "anyio", extras = ["trio"], specifier = ">=3.2.1,<5.0.0" },
+    { name = "coverage", extras = ["toml"], specifier = ">=7.10.1" },
+    { name = "fakeredis", specifier = ">=2.35.0" },
+    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
+    { name = "lupa", specifier = ">=2.8" },
+    { name = "pytest", specifier = ">=9.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+]
+
+[[package]]
 name = "fastar"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1146,6 +1238,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/05ce4745b191633f90ff1ab50f1a19a37da282bb0a41fb500d9157fc9b8f/lupa-2.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:97bd01e90b8031e56a5fd5bb70605aea09f1dba675c1140308a52780f93d06f1", size = 1202714, upload-time = "2026-04-15T20:05:31.088Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d2/f70fdbeec2d4c69ee6a469e6cddde9635fff4af4e13fb652e6a1229eef51/lupa-2.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b5ebe1a13c45767919c86750b84fe2da9f6288b6f3cea4ce7660bb2abc9d921", size = 1857453, upload-time = "2026-04-15T20:05:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/97/dc/6fcda0e36e75eb6cb98dc9190fa4737d727eeae29e58f892980b2c96b656/lupa-2.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:097e7d0f1719a88020b67c82e05d53d7973c166952393afcecfd8434c7e19a15", size = 2408890, upload-time = "2026-04-15T20:05:37.994Z" },
+    { url = "https://files.pythonhosted.org/packages/58/29/7ea176eac3c1dac83d059762daa875ad1390decc0bf2c3b4c7bbfc1f1665/lupa-2.8-cp310-cp310-win_amd64.whl", hash = "sha256:7bb223ee8f72d0dc076b0d65296ee72f1c69450f9d2fed5315f7707d98c4a03d", size = 1910396, upload-time = "2026-04-15T20:05:41.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/0a/5a740717f27aa77481e6a61b97cf79d1e0c1ede729b1268caacded915326/lupa-2.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b12e43c1fb787189dfc28cd604aef0baa2cb95e27da19498d520361d0ace070a", size = 1202376, upload-time = "2026-04-15T20:05:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/75/6b64d0098c64275a801896cb7a6a30e7e653d25fa102c64e747292afcdbb/lupa-2.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f603391dffb256e36a79fd2044084d5f4b8a0a4c0e5ad291cd3ab3aaf1fd0a", size = 1839271, upload-time = "2026-04-15T20:05:47.399Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2f/0d4f00563046ff616ef6a421f8b776a5ffb327f7b32ed69e856d52b917a8/lupa-2.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f6f41c91366e7d0d474f87d81c1274af861f40812bf729c9f97ab4c8f3c7ac8", size = 2376251, upload-time = "2026-04-15T20:05:49.891Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/8e/caa83237f427d9e85b7f02c816e7270c9c9571dec1673e06b0180402f70e/lupa-2.8-cp311-cp311-win_amd64.whl", hash = "sha256:f5a6af145b0ea818f01d27bfe2583a4b538570bef61d22c8773e0eccf011234c", size = 1923488, upload-time = "2026-04-15T20:05:52.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/17/fa834b6b09ad17e7df5d0f7715d64877a125a3776ada689751a1f9dc2959/lupa-2.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:450650f91c48c2415b0d59ab3abfcfda3b6efb5b858205f4d4bda8ad141fa529", size = 1190111, upload-time = "2026-04-15T20:06:32.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/43/45589901b7d1a0e3a9d91d19a311fb6a56924e8571536c3f2212160fd953/lupa-2.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27044f3363047f946b3d3aab9157cbd172b3538ada9ec1baef43432bf7d03a78", size = 1812999, upload-time = "2026-04-15T20:06:35.664Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ac/4ade7d15ff5c61758d7943ac6f0a496bf1cc65b6c09f842b52a0702e664c/lupa-2.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cf4f064a0e5531afce2d7d750120c10c10f9529139af6ca6150d13151034398", size = 2368731, upload-time = "2026-04-15T20:06:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/27/05f950d15b8ab120b39c43588b438ff3ace70c1b1b0225a960393a497483/lupa-2.8-cp312-cp312-win_amd64.whl", hash = "sha256:281bedc5deb92d31e649a3552edd662449365a635904fa4d5cb4509c7245e34e", size = 1941809, upload-time = "2026-04-15T20:06:40.302Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f7/e78df680c7a0ea452daac07467ca188d63c2c00ca1c884c0a50e27eb83b5/lupa-2.8-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32e4e5103bbddcdd2458fb2ccae6c8ba11c9997c711d7e379e0d45551d109c76", size = 1778509, upload-time = "2026-04-15T20:08:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/23/0e53cabb16b2a8aa9cf1fde499c097d8942c5dab709fc8e921f3b824b18b/lupa-2.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7667001804657496dee9feced2daae5000b4604a3218dd8e6b7b754982ba88b8", size = 2300480, upload-time = "2026-04-15T20:08:24.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/85/0271227eab939921a12ebba5d17aa4cd18346aa534ca7f5da09cd0b63dd4/lupa-2.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:86f6f668966965b15247dc32d064cfe7be67b71e584ccfacbe2f637575296878", size = 1847445, upload-time = "2026-04-15T20:08:27.031Z" },
 ]
 
 [[package]]
@@ -1880,94 +2035,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/31/1476f206482dd9bc53fdbbe9f6fbd5e05d153f18e54667ce839df331f2e6/redis-7.2.1.tar.gz", hash = "sha256:6163c1a47ee2d9d01221d8456bc1c75ab953cbda18cfbc15e7140e9ba16ca3a5", size = 4906735, upload-time = "2026-02-25T20:05:18.171Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/98/1dd1a5c060916cf21d15e67b7d6a7078e26e2605d5c37cbc9f4f5454c478/redis-7.2.1-py3-none-any.whl", hash = "sha256:49e231fbc8df2001436ae5252b3f0f3dc930430239bfeb6da4c7ee92b16e5d33", size = 396057, upload-time = "2026-02-25T20:05:16.533Z" },
-]
-
-[[package]]
-name = "fastapi-redis-sdk"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "fastapi", extra = ["standard"] },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "redis" },
-]
-
-[package.optional-dependencies]
-otel = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "anyio", extra = ["trio"] },
-    { name = "bandit", extra = ["toml"] },
-    { name = "coverage", extra = ["toml"] },
-    { name = "fakeredis" },
-    { name = "httpx" },
-    { name = "mypy" },
-    { name = "nox" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "pytest-timeout" },
-    { name = "ruff" },
-    { name = "safety" },
-    { name = "twine" },
-]
-test = [
-    { name = "anyio", extra = ["trio"] },
-    { name = "coverage", extra = ["toml"] },
-    { name = "fakeredis" },
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "pytest-timeout" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },
-    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20" },
-    { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.20" },
-    { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "redis", specifier = ">=6.0.0,<7.3.0" },
-]
-provides-extras = ["otel"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "anyio", extras = ["trio"], specifier = ">=3.2.1,<5.0.0" },
-    { name = "bandit", extras = ["toml"], specifier = ">=1.8.6" },
-    { name = "coverage", extras = ["toml"], specifier = ">=7.10.1" },
-    { name = "fakeredis", specifier = ">=2.35.0" },
-    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
-    { name = "mypy", specifier = ">=1.17.0" },
-    { name = "nox", specifier = ">=2026.4.10" },
-    { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "pytest-mock", specifier = ">=3.12.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "ruff", specifier = ">=0.12.5" },
-    { name = "safety", specifier = ">=3.6.0" },
-    { name = "twine", specifier = ">=4.0" },
-]
-test = [
-    { name = "anyio", extras = ["trio"], specifier = ">=3.2.1,<5.0.0" },
-    { name = "coverage", extras = ["toml"], specifier = ">=7.10.1" },
-    { name = "fakeredis", specifier = ">=2.35.0" },
-    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
-    { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.1.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
-    { name = "pytest-mock", specifier = ">=3.12.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Rate-limit FastAPI endpoints using Redis as the shared backend. Per request, atomically increment a per-client window counter via `INCREX` when available (Redis 8.8+) or a Lua script when it is not. Rejects excess requests with `429 Too Many Requests` and a `Retry-After` header.

```python
@app.get("/items", dependencies=[Depends(rate_limit(limit=100, window=60))])
async def get_items():
    return {"ok": True}
```

### Design

- **FastAPI dependency** — `rate_limit()` returns a `Depends()`-compatible callable (not a decorator or middleware), matching the `cache()` pattern
- **Default key** — client IP + method + path via `default_rate_limit_key_builder()`
- **Custom key builder** — sync or async callables accepted
- **Custom prefix** — override `redis:fastapi:ratelimit` with the `prefix=` parameter
- **INCREX path** — single `execute_command("INCREX", ...)` call; capability detected once per pool lifetime
- **Lua fallback** — atomic GET/INCR/EXPIRE via `execute_command("EVAL", ...)` when INCREX is unsupported

### Alternatives considered

- **`register_script()` / `eval()`** — most idiomatic redis-py approach, but the stubs annotate them as `self: Redis`, making them uncallable on the `AsyncRedis | AsyncRedisCluster` union. Stricter linters (mypy, basedpyright) would flag this, so we chose `execute_command()` which works cleanly on both types.
- **`EVALSHA` + fallback** — avoids sending the full script body on subsequent calls, but requires a try/except `NOSCRIPT` → `EVAL` pattern. We chose to avoid fallback patterns entirely.
- **`SCRIPT LOAD` at startup** — would pre-cache the SHA per connection, but needs per-connection lifecycle hooks that are fragile across reconnects. Not worth it for a 14-line script.

### New test dependency: `lupa`

`fakeredis` imports `lupa` directly for Lua script execution. Without it, the Lua fallback tests would crash. Scoped to `test` only — zero impact on production installs. If preferred, we can mock the Lua path to remove this dependency.

### OpenTelemetry

Every rate-limit check emits a `rate_limit.check` span with attributes (`key`, `limit`, `window`, `allowed`, `remaining`, `backend`) and increments a `redis_fastapi.rate_limit.requests` counter.

### Fail-open

Redis errors during the check are logged and swallowed; the request proceeds without rate limiting.

### Tests

- **17 unit tests** — allow/block/combinatorics, expired window, sync endpoint, custom key builder, Lua fallback, INCREX path, fail-open, key prefix
- **3 OTel tests** — span on allowed/blocked, metric recording
- **7 integration tests** — full request→Redis→response cycle via real Redis (auto-skipped without one)

### Open questions

- **Window unit** — `window=60` is seconds, matching INCREX `EX`. Rename to `window_seconds`, keep as-is, or accept `timedelta`?
- **Response headers** — currently `Retry-After` only. Add `X-RateLimit-*` on every response?
- **Query params in key** — default key excludes them. Include sorted params?
- **Fail policy** — currently fail-open (matching cache module). Prefer fail-closed for rate limiting?

Closes #15