### PR TITLE
fix: auto-enable cache telemetry when REDIS_OTEL_ENABLED is set

### DIFF
--- a/src/redis_fastapi/lifespan.py
+++ b/src/redis_fastapi/lifespan.py
@@ -67,11 +67,20 @@ async def redis_lifespan(app: FastAPI) -> AsyncIterator[None]:
     Supports both standalone and OSS Cluster modes based on
     ``get_settings().cluster``.
 
+    When ``settings.otel_enabled`` is ``True``, activates cache-layer
+    OpenTelemetry instrumentation (same effect as calling ``.otel()``).
+
     When ``settings.otel_redis_enabled`` is ``True``, also initializes
     redis-py's native OpenTelemetry integration on startup and shuts it
     down on teardown.
     """
     settings = get_settings()
+
+    # -- cache-layer OTel (optional) ---------------------------------------
+    if settings.otel_enabled:
+        from redis_fastapi.telemetry import enable_telemetry  # noqa: PLC0415
+
+        enable_telemetry()
 
     # -- redis-py native OTel (optional) -----------------------------------
     otel_instance: Any = None

--- a/tests/unit/test_lifespan_otel.py
+++ b/tests/unit/test_lifespan_otel.py
@@ -92,6 +92,76 @@ class TestShutdownRedisOtel:
 
 
 # ===================================================================
+# Lifespan with otel_enabled (cache-layer telemetry)
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestLifespanCacheOtelEnabled:
+    def test_enable_telemetry_called_when_otel_enabled(self):
+        """Lifespan calls enable_telemetry when otel_enabled=True."""
+        custom = RedisSettings(otel_enabled=True)
+
+        with (
+            patch("redis_fastapi.lifespan.get_settings", return_value=custom),
+            patch("redis_fastapi.deps.get_settings", return_value=custom),
+            patch("redis_fastapi.telemetry.enable_telemetry") as mock_enable,
+        ):
+            app = FastAPI()
+            FastAPIRedis(app).lifespan()
+
+            @app.get("/ping")
+            async def ping() -> dict:
+                return {"ok": True}
+
+            with TestClient(app) as client:
+                client.get("/ping")
+                mock_enable.assert_called_once()
+
+    def test_enable_telemetry_not_called_when_disabled(self):
+        """Lifespan does not call enable_telemetry when otel_enabled=False."""
+        custom = RedisSettings(otel_enabled=False)
+
+        with (
+            patch("redis_fastapi.lifespan.get_settings", return_value=custom),
+            patch("redis_fastapi.deps.get_settings", return_value=custom),
+            patch("redis_fastapi.telemetry.enable_telemetry") as mock_enable,
+        ):
+            app = FastAPI()
+            FastAPIRedis(app).lifespan()
+
+            @app.get("/ping")
+            async def ping() -> dict:
+                return {"ok": True}
+
+            with TestClient(app) as client:
+                client.get("/ping")
+                mock_enable.assert_not_called()
+
+    def test_otel_enabled_activates_is_enabled_on_startup(self):
+        """REDIS_OTEL_ENABLED / otel_enabled=True enables cache telemetry at startup."""
+        import redis_fastapi.telemetry as tel
+
+        custom = RedisSettings(otel_enabled=True)
+        original = tel._state
+        tel.disable_telemetry()
+        try:
+            with (
+                patch("redis_fastapi.lifespan.get_settings", return_value=custom),
+                patch("redis_fastapi.deps.get_settings", return_value=custom),
+            ):
+                app = FastAPI()
+                # Builder only — no explicit .otel(); matches issue #22 reproduction.
+                FastAPIRedis(app).lifespan().caching()
+                assert tel.is_enabled() is False
+
+                with TestClient(app):
+                    assert tel.is_enabled() is True
+        finally:
+            tel._state = original
+
+
+# ===================================================================
 # Lifespan with otel_redis_enabled
 # ===================================================================
 


### PR DESCRIPTION
## Summary

- Wire `RedisSettings.otel_enabled` (`REDIS_OTEL_ENABLED`) into `redis_lifespan()` so cache-layer OpenTelemetry is activated at startup without requiring an explicit `.otel()` call.
- Aligns runtime behavior with the configuration docs and with how `otel_redis_enabled` is already handled.
- Adds unit tests for the enabled path, disabled path, and the issue #22 reproduction (builder without `.otel()`).

## Context

Fixes #22.

The docs state that `REDIS_OTEL_ENABLED=true` alone is enough to enable cache telemetry. Previously `otel_enabled` was only defined on settings and never read; `enable_telemetry()` was only invoked from `FastAPIRedis.otel()`.

## Test plan

- [x] `uv run pytest tests/unit/test_lifespan_otel.py -q --no-cov` — 12 passed (includes 3 new tests)
- [x] Full suite with local Redis: `uv run pytest -q` — **294 passed**, 0 skipped, 98% coverage
- [x] Manual repro of issue #22:
  - `REDIS_OTEL_ENABLED=true` + `.lifespan().caching()` (no `.otel()`)
  - `is_enabled()` is `False` before startup, `True` after lifespan runs
  - Control: flag unset keeps telemetry disabled