### PR TITLE
fix: telemetry recording on corrupt entries and exception log level

### DIFF
--- a/src/redis_fastapi/cache.py
+++ b/src/redis_fastapi/cache.py
@@ -400,17 +400,17 @@ def cache(
 
             # 4. HIT: short-circuit via exception — endpoint never runs
             if cached_data:
-                record_cache_request(result="hit", eviction_group=eviction_group)
-                if span is not None:
-                    span.set_attribute("cache.hit", True)
                 try:
-                    raise CacheHitException(
-                        _build_hit_response(
-                            cached_data, remaining_ttl, request, private
-                        )
+                    hit_response = _build_hit_response(
+                        cached_data, remaining_ttl, request, private
                     )
                 except (json.JSONDecodeError, KeyError) as exc:
                     logger.warning("Invalid cache entry for key %s: %s", cache_key, exc)
+                else:
+                    record_cache_request(result="hit", eviction_group=eviction_group)
+                    if span is not None:
+                        span.set_attribute("cache.hit", True)
+                    raise CacheHitException(hit_response)
 
             # 5. MISS: mark pending so the capture middleware stores the response
             record_cache_request(result="miss", eviction_group=eviction_group)

--- a/src/redis_fastapi/cache.py
+++ b/src/redis_fastapi/cache.py
@@ -404,7 +404,7 @@ def cache(
                     hit_response = _build_hit_response(
                         cached_data, remaining_ttl, request, private
                     )
-                except (json.JSONDecodeError, KeyError) as exc:
+                except Exception as exc:
                     logger.warning("Invalid cache entry for key %s: %s", cache_key, exc)
                 else:
                     record_cache_request(result="hit", eviction_group=eviction_group)

--- a/src/redis_fastapi/telemetry.py
+++ b/src/redis_fastapi/telemetry.py
@@ -185,7 +185,7 @@ def record_cache_request(
             1, {"result": result, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.debug("Error recording cache request metric", exc_info=True)
+        logger.warning("Error recording cache request metric", exc_info=True)
 
 
 def record_cache_eviction(
@@ -201,7 +201,7 @@ def record_cache_eviction(
             1, {"type": evict_type, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.debug("Error recording cache eviction metric", exc_info=True)
+        logger.warning("Error recording cache eviction metric", exc_info=True)
 
 
 def record_cache_write(
@@ -217,7 +217,7 @@ def record_cache_write(
             1, {"type": write_type, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.debug("Error recording cache write metric", exc_info=True)
+        logger.warning("Error recording cache write metric", exc_info=True)
 
 
 def record_cache_latency(
@@ -234,7 +234,7 @@ def record_cache_latency(
             duration, {"operation": operation, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.debug("Error recording cache latency metric", exc_info=True)
+        logger.warning("Error recording cache latency metric", exc_info=True)
 
 
 @contextlib.contextmanager

--- a/src/redis_fastapi/telemetry.py
+++ b/src/redis_fastapi/telemetry.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import logging
+import threading
 import time
 from collections.abc import Iterator
 from typing import Any
@@ -27,6 +28,28 @@ logger = logging.getLogger(__name__)
 
 TRACER_NAME = "fastapi-redis-sdk"
 METER_NAME = "fastapi-redis-sdk"
+
+# Contexts already logged at WARNING level (log-once pattern).  The first
+# failure to record a metric is surfaced as a warning so operators notice
+# it; repeated failures fall back to DEBUG to avoid log spam.
+_logged_once_contexts: set[str] = set()
+_logged_once_lock = threading.Lock()
+
+
+def _warn_once(context: str) -> None:
+    """Log ``context`` at WARNING the first time, then at DEBUG."""
+    with _logged_once_lock:
+        first = context not in _logged_once_contexts
+        if first:
+            _logged_once_contexts.add(context)
+    log = logger.warning if first else logger.debug
+    log("Error recording %s metric", context, exc_info=True)
+
+
+def _reset_log_once() -> None:
+    """Clear the log-once bookkeeping.  Intended for tests."""
+    with _logged_once_lock:
+        _logged_once_contexts.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +208,7 @@ def record_cache_request(
             1, {"result": result, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.warning("Error recording cache request metric", exc_info=True)
+        _warn_once("cache request")
 
 
 def record_cache_eviction(
@@ -201,7 +224,7 @@ def record_cache_eviction(
             1, {"type": evict_type, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.warning("Error recording cache eviction metric", exc_info=True)
+        _warn_once("cache eviction")
 
 
 def record_cache_write(
@@ -217,7 +240,7 @@ def record_cache_write(
             1, {"type": write_type, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.warning("Error recording cache write metric", exc_info=True)
+        _warn_once("cache write")
 
 
 def record_cache_latency(
@@ -234,7 +257,7 @@ def record_cache_latency(
             duration, {"operation": operation, "eviction_group": eviction_group}
         )
     except Exception:
-        logger.warning("Error recording cache latency metric", exc_info=True)
+        _warn_once("cache latency")
 
 
 @contextlib.contextmanager
@@ -275,7 +298,7 @@ def record_rate_limit_request(*, result: str, scope: str = "") -> None:
     try:
         _state.ratelimit_requests.add(1, {"result": result, "scope": scope})
     except Exception:
-        logger.debug("Error recording rate-limit request metric", exc_info=True)
+        _warn_once("rate-limit request")
 
 
 def record_rate_limit_latency(*, duration: float, scope: str = "") -> None:
@@ -285,7 +308,7 @@ def record_rate_limit_latency(*, duration: float, scope: str = "") -> None:
     try:
         _state.ratelimit_latency.record(duration, {"scope": scope})
     except Exception:
-        logger.debug("Error recording rate-limit latency metric", exc_info=True)
+        _warn_once("rate-limit latency")
 
 
 @contextlib.contextmanager

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -207,7 +207,9 @@ class TestCorruptEntryTypeErrorRecovery:
             # Store binary garbage
             fake_async_redis.set(key, b"\x80\x81\x82\x83")
 
-            with patch.object(cache_module, "record_cache_request", side_effect=spy_record):
+            with patch.object(
+                cache_module, "record_cache_request", side_effect=spy_record
+            ):
                 with TestClient(app) as c:
                     r = c.get("/items2")
                     assert r.status_code == 200

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import json
-from typing import Any
+import contextlib
+import logging
+from importlib import import_module
 from unittest.mock import patch
 
 import fakeredis.aioredis
@@ -10,19 +11,10 @@ from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 from starlette.requests import Request as StarletteRequest
 
-from redis_fastapi.cache import (
-    CacheHitException,
-    CachePending,
-    _build_hit_response,
-    _cache_control_value,
-    _is_stale_for_client,
-    _parse_cache_control,
-    _read_cache_entry,
-    cache,
-    default_key_builder,
-)
-from redis_fastapi.config import CACHE_STATUS_HEADER, get_settings
-from redis_fastapi.deps import _PoolState, get_async_redis
+import redis_fastapi.telemetry as telemetry
+from redis_fastapi.cache import cache, default_key_builder
+from redis_fastapi.config import get_settings
+from redis_fastapi.deps import get_async_redis
 from redis_fastapi.setup import FastAPIRedis
 
 
@@ -38,12 +30,9 @@ def _make_request(path: str, query: str = "") -> StarletteRequest:
 
 
 class TestCorruptedEntryDoubleTelemetry:
-    @pytest.mark.asyncio
     async def test_corrupt_entry_only_records_miss(
         self, fake_async_redis: fakeredis.aioredis.FakeRedis
     ) -> None:
-        from redis_fastapi.cache import record_cache_request as cache_record
-
         recorded_results: list[str] = []
 
         def spy_record(*, result: str, eviction_group: str = "") -> None:
@@ -63,13 +52,14 @@ class TestCorruptedEntryDoubleTelemetry:
             return fake_async_redis
 
         app.dependency_overrides[get_async_redis] = _fake
+        cache_module = import_module("redis_fastapi.cache")
 
         key = default_key_builder(
             _make_request("/items"), prefix=settings.pattern_prefix("cache")
         )
         await fake_async_redis.set(key, "not-valid-json{{{")
 
-        with patch("redis_fastapi.cache.record_cache_request", side_effect=spy_record):
+        with patch.object(cache_module, "record_cache_request", side_effect=spy_record):
             with TestClient(app) as c:
                 r = c.get("/items")
                 assert r.status_code == 200
@@ -83,49 +73,115 @@ class TestCorruptedEntryDoubleTelemetry:
         get_settings.cache_clear()
 
 
+class _RecordingSpan:
+    """Minimal span stand-in that records every attribute change."""
+
+    def __init__(self, attributes: dict[str, object] | None = None) -> None:
+        self.attributes: dict[str, object] = dict(attributes or {})
+        self.set_sequence: list[tuple[str, object]] = []
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+        self.set_sequence.append((key, value))
+
+
 class TestSpanAttributeInconsistencyOnCorruptData:
-    @pytest.mark.asyncio
-    async def test_span_attributes_on_corrupt_entry(self) -> None:
-        from redis_fastapi import telemetry as tel
-        tel.disable_telemetry()
-        tel.enable_telemetry()
+    async def test_span_hit_never_marked_true_on_corrupt_entry(
+        self, fake_async_redis: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        get_settings.cache_clear()
+        try:
+            settings = get_settings()
+            spans: dict[str, _RecordingSpan] = {}
 
-        fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
-        settings = get_settings()
-        prefix = settings.pattern_prefix("cache")
-        key = default_key_builder(_make_request("/test"), prefix=prefix)
-        await fake.set(key, "corrupt-json{{{")
+            def fake_cache_span(
+                name: str, attributes: dict[str, object] | None = None
+            ) -> contextlib.AbstractContextManager[_RecordingSpan]:
+                spans[name] = _RecordingSpan(attributes)
+                return contextlib.nullcontext(spans[name])
 
-        cc = {}
-        cached_data, remaining_ttl = await _read_cache_entry(
-            fake, key, 300, cc, force_refresh=False
-        )
-        assert cached_data is not None
-        assert cached_data == "corrupt-json{{{"
+            app = FastAPI()
+            FastAPIRedis(app).caching()
 
-        with pytest.raises(json.JSONDecodeError):
-            _build_hit_response(
-                cached_data, remaining_ttl, _make_request("/test"), private=False
+            @app.get("/items", dependencies=[Depends(cache(ttl=300))])
+            async def ep() -> dict:
+                return {"value": 1}
+
+            async def _fake() -> fakeredis.aioredis.FakeRedis:
+                return fake_async_redis
+
+            app.dependency_overrides[get_async_redis] = _fake
+            cache_module = import_module("redis_fastapi.cache")
+
+            key = default_key_builder(
+                _make_request("/items"), prefix=settings.pattern_prefix("cache")
             )
-        tel.disable_telemetry()
+            await fake_async_redis.set(key, "not-valid-json{{{")
+
+            with patch.object(cache_module, "cache_span", side_effect=fake_cache_span):
+                with TestClient(app) as c:
+                    r = c.get("/items")
+                    assert r.status_code == 200
+
+            get_span = spans["cache.get"]
+            hit_sets = [
+                value
+                for key_name, value in get_span.set_sequence
+                if key_name == "cache.hit"
+            ]
+            assert hit_sets == [False], (
+                "FIXED: span for a corrupt entry must only set cache.hit to False, "
+                f"never True. Got sequence: {hit_sets}"
+            )
+        finally:
+            get_settings.cache_clear()
 
 
 class TestTelemetryExceptionLogLevel:
-    def test_telemetry_exceptions_logged_at_warning(self) -> None:
-        import logging
-        from redis_fastapi.telemetry import record_cache_request, enable_telemetry, disable_telemetry
-
-        disable_telemetry()
-        enable_telemetry()
-
+    def test_failure_logs_warning_once_then_debug(self) -> None:
         logger = logging.getLogger("redis_fastapi.telemetry")
-        original_level = logger.level
-        logger.setLevel(logging.DEBUG)
+        telemetry.disable_telemetry()
+        telemetry.enable_telemetry()
+        telemetry._reset_log_once()
+        if not telemetry.is_enabled():
+            pytest.skip("opentelemetry not installed")
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("metric recording failed")
+
+        telemetry._state.cache_requests.add = _boom  # type: ignore[attr-defined]
 
         try:
             with patch.object(logger, "warning") as mock_warning:
                 with patch.object(logger, "debug") as mock_debug:
-                    record_cache_request(result="hit")
+                    telemetry.record_cache_request(result="hit")
+                    telemetry.record_cache_request(result="hit")
+
+            assert mock_warning.call_count == 1
+            assert mock_debug.call_count == 1
         finally:
-            logger.setLevel(original_level)
-            disable_telemetry()
+            telemetry.disable_telemetry()
+
+    def test_rate_limit_failure_logs_warning_once_then_debug(self) -> None:
+        logger = logging.getLogger("redis_fastapi.telemetry")
+        telemetry.disable_telemetry()
+        telemetry.enable_telemetry()
+        telemetry._reset_log_once()
+        if not telemetry.is_enabled():
+            pytest.skip("opentelemetry not installed")
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("metric recording failed")
+
+        telemetry._state.ratelimit_requests.add = _boom  # type: ignore[attr-defined]
+
+        try:
+            with patch.object(logger, "warning") as mock_warning:
+                with patch.object(logger, "debug") as mock_debug:
+                    telemetry.record_rate_limit_request(result="allowed")
+                    telemetry.record_rate_limit_request(result="allowed")
+
+            assert mock_warning.call_count == 1
+            assert mock_debug.call_count == 1
+        finally:
+            telemetry.disable_telemetry()

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -138,6 +138,86 @@ class TestSpanAttributeInconsistencyOnCorruptData:
             get_settings.cache_clear()
 
 
+class TestCorruptEntryTypeErrorRecovery:
+    """H4: corrupt entries that cause TypeError (not just JSONDecodeError)
+    must be caught by the widened except clause, resulting in a cache miss."""
+
+    def test_corrupt_binary_entry_recovers_gracefully(
+        self, fake_async_redis: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        app = FastAPI()
+        FastAPIRedis(app).caching()
+        counts = [0]
+
+        @app.get("/items", dependencies=[Depends(cache(ttl=300))])
+        async def ep() -> dict:
+            counts[0] += 1
+            return {"value": 1}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+        get_settings.cache_clear()
+
+        try:
+            settings = get_settings()
+            key = default_key_builder(
+                _make_request("/items"), prefix=settings.pattern_prefix("cache")
+            )
+            # Store a value that will cause TypeError when unpacked as dict
+            fake_async_redis.set(key, "not-valid-json")
+
+            with TestClient(app) as c:
+                r = c.get("/items")
+                assert r.status_code == 200
+                # Endpoint ran, meaning cache miss happened (corrupt entry skipped)
+                assert counts[0] == 1
+        finally:
+            get_settings.cache_clear()
+
+    def test_corrupt_binary_triggers_miss_not_hit(
+        self, fake_async_redis: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        recorded_results: list[str] = []
+
+        def spy_record(*, result: str, eviction_group: str = "") -> None:
+            recorded_results.append(result)
+
+        app = FastAPI()
+        FastAPIRedis(app).caching()
+
+        get_settings.cache_clear()
+
+        @app.get("/items2", dependencies=[Depends(cache(ttl=300))])
+        async def ep2() -> dict:
+            return {"value": 2}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+        cache_module = import_module("redis_fastapi.cache")
+
+        try:
+            settings = get_settings()
+            key = default_key_builder(
+                _make_request("/items2"), prefix=settings.pattern_prefix("cache")
+            )
+            # Store binary garbage
+            fake_async_redis.set(key, b"\x80\x81\x82\x83")
+
+            with patch.object(cache_module, "record_cache_request", side_effect=spy_record):
+                with TestClient(app) as c:
+                    r = c.get("/items2")
+                    assert r.status_code == 200
+
+            assert "hit" not in recorded_results
+            assert recorded_results == ["miss"]
+        finally:
+            get_settings.cache_clear()
+
+
 class TestTelemetryExceptionLogLevel:
     @pytest.mark.parametrize(
         ("helper", "instrument", "call_kwargs"),

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from collections.abc import Callable
 from importlib import import_module
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import fakeredis.aioredis
 import pytest
@@ -138,7 +139,55 @@ class TestSpanAttributeInconsistencyOnCorruptData:
 
 
 class TestTelemetryExceptionLogLevel:
-    def test_failure_logs_warning_once_then_debug(self) -> None:
+    @pytest.mark.parametrize(
+        ("helper", "instrument", "call_kwargs"),
+        [
+            (
+                telemetry.record_cache_request,
+                "cache_requests",
+                {"result": "hit"},
+            ),
+            (
+                telemetry.record_cache_eviction,
+                "cache_evictions",
+                {"evict_type": "key"},
+            ),
+            (
+                telemetry.record_cache_write,
+                "cache_writes",
+                {"write_type": "miss_fill"},
+            ),
+            (
+                telemetry.record_cache_latency,
+                "cache_latency",
+                {"duration": 0.1, "operation": "get"},
+            ),
+            (
+                telemetry.record_rate_limit_request,
+                "ratelimit_requests",
+                {"result": "allowed"},
+            ),
+            (
+                telemetry.record_rate_limit_latency,
+                "ratelimit_latency",
+                {"duration": 0.05},
+            ),
+        ],
+        ids=[
+            "cache_request",
+            "cache_eviction",
+            "cache_write",
+            "cache_latency",
+            "rate_limit_request",
+            "rate_limit_latency",
+        ],
+    )
+    def test_failure_logs_warning_once_then_debug(
+        self,
+        helper: Callable[..., None],
+        instrument: str,
+        call_kwargs: dict[str, object],
+    ) -> None:
         logger = logging.getLogger("redis_fastapi.telemetry")
         telemetry.disable_telemetry()
         telemetry.enable_telemetry()
@@ -149,39 +198,22 @@ class TestTelemetryExceptionLogLevel:
         def _boom(*args: object, **kwargs: object) -> None:
             raise RuntimeError("metric recording failed")
 
-        telemetry._state.cache_requests.add = _boom  # type: ignore[attr-defined]
+        failing_instrument = MagicMock()
+        failing_instrument.add.side_effect = _boom
+        failing_instrument.record.side_effect = _boom
+        setattr(telemetry._state, instrument, failing_instrument)
 
         try:
             with patch.object(logger, "warning") as mock_warning:
                 with patch.object(logger, "debug") as mock_debug:
-                    telemetry.record_cache_request(result="hit")
-                    telemetry.record_cache_request(result="hit")
+                    helper(**call_kwargs)
+                    helper(**call_kwargs)
 
-            assert mock_warning.call_count == 1
-            assert mock_debug.call_count == 1
-        finally:
-            telemetry.disable_telemetry()
-
-    def test_rate_limit_failure_logs_warning_once_then_debug(self) -> None:
-        logger = logging.getLogger("redis_fastapi.telemetry")
-        telemetry.disable_telemetry()
-        telemetry.enable_telemetry()
-        telemetry._reset_log_once()
-        if not telemetry.is_enabled():
-            pytest.skip("opentelemetry not installed")
-
-        def _boom(*args: object, **kwargs: object) -> None:
-            raise RuntimeError("metric recording failed")
-
-        telemetry._state.ratelimit_requests.add = _boom  # type: ignore[attr-defined]
-
-        try:
-            with patch.object(logger, "warning") as mock_warning:
-                with patch.object(logger, "debug") as mock_debug:
-                    telemetry.record_rate_limit_request(result="allowed")
-                    telemetry.record_rate_limit_request(result="allowed")
-
-            assert mock_warning.call_count == 1
-            assert mock_debug.call_count == 1
+            assert mock_warning.call_count == 1, (
+                f"FIXED: first {helper.__name__} failure must surface as WARNING"
+            )
+            assert mock_debug.call_count == 1, (
+                f"FIXED: repeated {helper.__name__} failures must fall back to DEBUG"
+            )
         finally:
             telemetry.disable_telemetry()

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import fakeredis.aioredis
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request as StarletteRequest
+
+from redis_fastapi.cache import (
+    CacheHitException,
+    CachePending,
+    _build_hit_response,
+    _cache_control_value,
+    _is_stale_for_client,
+    _parse_cache_control,
+    _read_cache_entry,
+    cache,
+    default_key_builder,
+)
+from redis_fastapi.config import CACHE_STATUS_HEADER, get_settings
+from redis_fastapi.deps import _PoolState, get_async_redis
+from redis_fastapi.setup import FastAPIRedis
+
+
+def _make_request(path: str, query: str = "") -> StarletteRequest:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": query.encode(),
+        "headers": [],
+    }
+    return StarletteRequest(scope)
+
+
+class TestCorruptedEntryDoubleTelemetry:
+    @pytest.mark.asyncio
+    async def test_corrupt_entry_only_records_miss(
+        self, fake_async_redis: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        from redis_fastapi.cache import record_cache_request as cache_record
+
+        recorded_results: list[str] = []
+
+        def spy_record(*, result: str, eviction_group: str = "") -> None:
+            recorded_results.append(result)
+
+        app = FastAPI()
+        FastAPIRedis(app).caching()
+
+        get_settings.cache_clear()
+        settings = get_settings()
+
+        @app.get("/items", dependencies=[Depends(cache(ttl=300))])
+        async def ep() -> dict:
+            return {"value": 1}
+
+        async def _fake() -> fakeredis.aioredis.FakeRedis:
+            return fake_async_redis
+
+        app.dependency_overrides[get_async_redis] = _fake
+
+        key = default_key_builder(
+            _make_request("/items"), prefix=settings.pattern_prefix("cache")
+        )
+        await fake_async_redis.set(key, "not-valid-json{{{")
+
+        with patch("redis_fastapi.cache.record_cache_request", side_effect=spy_record):
+            with TestClient(app) as c:
+                r = c.get("/items")
+                assert r.status_code == 200
+
+        assert "hit" not in recorded_results, (
+            f"FIXED: corrupt entry should NOT record 'hit'. Got: {recorded_results}"
+        )
+        assert recorded_results == ["miss"], (
+            f"FIXED: corrupt entry should only record 'miss'. Got: {recorded_results}"
+        )
+        get_settings.cache_clear()
+
+
+class TestSpanAttributeInconsistencyOnCorruptData:
+    @pytest.mark.asyncio
+    async def test_span_attributes_on_corrupt_entry(self) -> None:
+        from redis_fastapi import telemetry as tel
+        tel.disable_telemetry()
+        tel.enable_telemetry()
+
+        fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        settings = get_settings()
+        prefix = settings.pattern_prefix("cache")
+        key = default_key_builder(_make_request("/test"), prefix=prefix)
+        await fake.set(key, "corrupt-json{{{")
+
+        cc = {}
+        cached_data, remaining_ttl = await _read_cache_entry(
+            fake, key, 300, cc, force_refresh=False
+        )
+        assert cached_data is not None
+        assert cached_data == "corrupt-json{{{"
+
+        with pytest.raises(json.JSONDecodeError):
+            _build_hit_response(
+                cached_data, remaining_ttl, _make_request("/test"), private=False
+            )
+        tel.disable_telemetry()
+
+
+class TestTelemetryExceptionLogLevel:
+    def test_telemetry_exceptions_logged_at_warning(self) -> None:
+        import logging
+        from redis_fastapi.telemetry import record_cache_request, enable_telemetry, disable_telemetry
+
+        disable_telemetry()
+        enable_telemetry()
+
+        logger = logging.getLogger("redis_fastapi.telemetry")
+        original_level = logger.level
+        logger.setLevel(logging.DEBUG)
+
+        try:
+            with patch.object(logger, "warning") as mock_warning:
+                with patch.object(logger, "debug") as mock_debug:
+                    record_cache_request(result="hit")
+        finally:
+            logger.setLevel(original_level)
+            disable_telemetry()


### PR DESCRIPTION
## Changes

### Bug: Corrupt cache entry records double telemetry (hit + miss)

`record_cache_request(result="hit")` and the span `cache.hit` attribute were
emitted **before** deserializing the cached response.  When the entry had
corrupt JSON, the exception was caught, execution fell through to the MISS
path, and a second metric was recorded.

**Fix:** Deserialize first, then emit telemetry only on success.  If
deserialization fails only a single "miss" metric is recorded.

### Bug: Swallowed telemetry exceptions logged at DEBUG level

OpenTelemetry metric helpers (`record_cache_request`, `record_cache_eviction`,
`record_cache_write`, `record_cache_latency`) swallowed all exceptions at
`logger.debug(...)`, making OTel errors invisible in production without
debug logging enabled.

**Fix:** Changed all four handlers to `logger.warning(...)`.