### PR TITLE
Implement Redis-backed WebSocket Pub/Sub helpers

### DIFF
--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -169,3 +169,52 @@ def default_key_builder(request: Request, eviction_group: str = "", prefix: str 
 ```
 
 Builds a cache key from the request path (slashes → colons) and sorted query params. Eviction group is wrapped in Redis hash-tag braces (`{eviction_group}`) for Cluster slot consistency.
+
+---
+
+## Pub/Sub dependencies
+
+### `PubSubManagerDep`
+
+```python
+from redis_fastapi import PubSubManagerDep
+
+@app.post("/notify")
+async def notify(message: str, pubsub: PubSubManagerDep):
+    count = await pubsub.publish("notifications", message)
+    return {"subscribers": count}
+```
+
+`Annotated[PubSubManager, Depends(get_pubsub_manager)]` - publishes messages to Redis channels from HTTP endpoints.
+
+### `get_pubsub_manager()`
+
+```python
+async def get_pubsub_manager(request: Request) -> PubSubManager
+```
+
+Factory function underlying `PubSubManagerDep`.
+
+### `PubSubManager`
+
+```python
+from redis_fastapi import PubSubManager
+
+pubsub = PubSubManager(redis)
+await pubsub.subscribe("channel")
+async for message in pubsub.listen():
+    ...
+await pubsub.close()
+```
+
+Wraps Redis Pub/Sub for real-time messaging. Uses a dedicated PubSub connection from the shared pool. For WebSocket endpoints, construct directly rather than using `PubSubManagerDep`.
+
+| Method | Description |
+|--------|-------------|
+| `subscribe(*channels)` | Subscribe to one or more Redis channels |
+| `unsubscribe(*channels)` | Unsubscribe from channels |
+| `publish(channel, message) -> int` | Publish a message, returns subscriber count |
+| `listen() -> AsyncIterator[dict]` | Yield `message`-type PubSub events |
+| `close()` | Unsubscribe all and close the connection |
+
+See the [Pub/Sub guide](../guide/pubsub.md) for WebSocket examples and best practices.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -39,10 +39,10 @@ async def handler(redis: AsyncRedisDep):
 ### `get_async_redis()`
 
 ```python
-async def get_async_redis(request: Request) -> AsyncRedis | AsyncRedisCluster
+async def get_async_redis(connection: HTTPConnection) -> AsyncRedis | AsyncRedisCluster
 ```
 
-Async function underlying `AsyncRedisDep`. Returns the same client instance on every call (no per-request overhead). Raises `RuntimeError` if no lifespan has initialised the pool.
+Async function underlying `AsyncRedisDep`. Accepts both HTTP ``Request`` and ``WebSocket`` (``HTTPConnection`` is their common base), so it works in both endpoint types. Returns the same client instance on every call (no per-request overhead). Raises ``RuntimeError`` if no lifespan has initialised the pool.
 
 ---
 
@@ -185,12 +185,12 @@ async def notify(message: str, pubsub: PubSubManagerDep):
     return {"subscribers": count}
 ```
 
-`Annotated[PubSubManager, Depends(get_pubsub_manager)]` - publishes messages to Redis channels from HTTP endpoints.
+`Annotated[PubSubManager, Depends(get_pubsub_manager)]` - publishes messages to Redis channels. Works in both HTTP endpoints and WebSocket handlers because ``get_async_redis`` accepts ``HTTPConnection``.
 
 ### `get_pubsub_manager()`
 
 ```python
-async def get_pubsub_manager(request: Request) -> PubSubManager
+async def get_pubsub_manager(connection: HTTPConnection) -> PubSubManager
 ```
 
 Factory function underlying `PubSubManagerDep`.

--- a/docs/guide/pubsub.md
+++ b/docs/guide/pubsub.md
@@ -46,33 +46,26 @@ The returned integer is the number of subscribers that received the message
 
 ## WebSocket subscriptions
 
-For WebSocket endpoints, construct `PubSubManager` directly from the app
-state; FastAPI's dependency injection for WebSocket connections does not
-resolve `Request`-based dependencies:
+``PubSubManagerDep`` works in WebSocket handlers directly because
+``get_async_redis`` accepts ``HTTPConnection``, the common base type
+of both ``Request`` and ``WebSocket``:
 
 ```python
 from fastapi import WebSocket
-from redis_fastapi import PubSubManager
-from redis_fastapi.deps import _get_pool_state
+from redis_fastapi import PubSubManagerDep
 
 @app.websocket("/ws/chat/{room}")
-async def chat(websocket: WebSocket, room: str):
+async def chat(websocket: WebSocket, room: str, pubsub: PubSubManagerDep):
     await websocket.accept()
-
-    # Create PubSubManager from the app's shared pool
-    redis = _get_pool_state(websocket.app).get_async_client()
-    pubsub = PubSubManager(redis)
 
     channel = f"chat:{room}"
     await pubsub.subscribe(channel)
 
     async def forward_to_ws():
-        """Forward Redis messages to the WebSocket client."""
         async for message in pubsub.listen():
             await websocket.send_text(message["data"].decode())
 
     async def forward_to_redis():
-        """Forward WebSocket messages to Redis."""
         async for data in websocket.iter_text():
             await pubsub.publish(channel, data)
 

--- a/docs/guide/pubsub.md
+++ b/docs/guide/pubsub.md
@@ -1,0 +1,178 @@
+# Pub/Sub
+
+Redis [Pub/Sub](https://redis.io/docs/latest/develop/interact/pubsub/) enables
+real-time messaging between application instances.  fastapi-redis-sdk provides
+a `PubSubManager` that wraps Redis Pub/Sub for use in WebSocket endpoints and
+background tasks, reusing the shared async pool.
+
+## When to use Pub/Sub
+
+| Scenario | Example |
+|----------|---------|
+| Cross-worker chat rooms | Multiple server instances subscribe to the same channel |
+| Real-time notifications | Broadcast events to connected WebSocket clients |
+| Live updates | Push data changes to browsers without polling |
+| Broadcasts | Send the same message to all subscribers |
+
+## Setup
+
+`PubSubManager` only needs a Redis connection pool; no additional
+middleware or configuration is required:
+
+```python
+from fastapi import FastAPI
+from redis_fastapi import FastAPIRedis
+
+app = FastAPI()
+FastAPIRedis(app).lifespan()  # pool is set up; Pub/Sub is ready
+```
+
+## Publishing messages
+
+Use `PubSubManagerDep` from any HTTP endpoint to publish messages:
+
+```python
+from fastapi import Depends
+from redis_fastapi import PubSubManagerDep
+
+@app.post("/notify")
+async def notify(message: str, pubsub: PubSubManagerDep):
+    count = await pubsub.publish("notifications", message)
+    return {"subscribers": count}
+```
+
+The returned integer is the number of subscribers that received the message
+(across all connected Redis clients).
+
+## WebSocket subscriptions
+
+For WebSocket endpoints, construct `PubSubManager` directly from the app
+state; FastAPI's dependency injection for WebSocket connections does not
+resolve `Request`-based dependencies:
+
+```python
+from fastapi import WebSocket
+from redis_fastapi import PubSubManager
+from redis_fastapi.deps import _get_pool_state
+
+@app.websocket("/ws/chat/{room}")
+async def chat(websocket: WebSocket, room: str):
+    await websocket.accept()
+
+    # Create PubSubManager from the app's shared pool
+    redis = _get_pool_state(websocket.app).get_async_client()
+    pubsub = PubSubManager(redis)
+
+    channel = f"chat:{room}"
+    await pubsub.subscribe(channel)
+
+    async def forward_to_ws():
+        """Forward Redis messages to the WebSocket client."""
+        async for message in pubsub.listen():
+            await websocket.send_text(message["data"].decode())
+
+    async def forward_to_redis():
+        """Forward WebSocket messages to Redis."""
+        async for data in websocket.iter_text():
+            await pubsub.publish(channel, data)
+
+    try:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(forward_to_ws)
+            tg.start_soon(forward_to_redis)
+    except Exception:
+        pass
+    finally:
+        await pubsub.close()
+```
+
+The `listen()` method yields only `message`-type events; system messages
+(subscription confirmations, etc.) are filtered out automatically.
+
+## Broadcasting
+
+Publish to a channel without subscribing:
+
+```python
+@app.post("/broadcast")
+async def broadcast(message: str, pubsub: PubSubManagerDep):
+    count = await pubsub.publish("broadcasts", message)
+    return {"sent_to": count}
+```
+
+## Managing subscriptions
+
+Subscribe to multiple channels at once:
+
+```python
+await pubsub.subscribe("channel:a", "channel:b", "channel:c")
+```
+
+Unsubscribe selectively:
+
+```python
+await pubsub.unsubscribe("channel:a")
+```
+
+Unsubscribe all and close:
+
+```python
+await pubsub.close()
+```
+
+`close()` is safe to call multiple times and handles cleanup gracefully
+even if the underlying connection was never established.
+
+## Testing
+
+Unit tests can use `fakeredis` to simulate Pub/Sub without a real Redis
+server:
+
+```python
+import fakeredis.aioredis
+from redis_fastapi import PubSubManager
+
+async def test_pubsub():
+    fake = fakeredis.aioredis.FakeRedis()
+    pubsub = PubSubManager(fake)
+
+    # Subscribe and publish in sequence
+    await pubsub.subscribe("test:ch")
+
+    # Listen for the published message
+    async def publish_later():
+        import anyio
+        await anyio.sleep(0.05)
+        await pubsub.publish("test:ch", "hello")
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(publish_later)
+        async for message in pubsub.listen():
+            assert message["data"] == b"hello"
+            break
+
+    await pubsub.close()
+```
+
+## Limitations
+
+Redis Pub/Sub is **transient and at-most-once**:
+
+- Messages are **not persisted**; if a subscriber disconnects, it misses
+  messages sent while offline.
+- There is **no message acknowledgement**; if a subscriber crashes after
+  receiving a message, that message is lost.
+- Delivery is **at-most-once**; a message is delivered zero or one times.
+
+For persistent message queues with consumer groups, see
+[Redis Streams](https://redis.io/docs/latest/develop/data-types/streams/).
+
+## API Reference
+
+| Method | Description |
+|--------|-------------|
+| `subscribe(*channels)` | Subscribe to one or more Redis channels |
+| `unsubscribe(*channels)` | Unsubscribe from Redis channels |
+| `publish(channel, message)` | Publish a message, returns subscriber count |
+| `listen()` | Async generator yielding `message`-type PubSub events |
+| `close()` | Unsubscribe all + close the PubSub connection |

--- a/examples/main.py
+++ b/examples/main.py
@@ -28,7 +28,6 @@ from redis_fastapi import (
     AsyncRedisDep,
     CacheBackendDep,
     FastAPIRedis,
-    PubSubManager,
     PubSubManagerDep,
     cache,
     cache_evict,
@@ -36,7 +35,6 @@ from redis_fastapi import (
     get_settings,
 )
 from redis_fastapi.config import RedisSettings
-from redis_fastapi.deps import _get_pool_state
 
 app = FastAPI(
     title="fastapi-redis-sdk demo",
@@ -141,14 +139,12 @@ async def notify(message: str, pubsub: PubSubManagerDep) -> dict[str, int]:
 
 
 @app.websocket("/ws/chat/{room}")
-async def chat(websocket: WebSocket, room: str) -> None:
+async def chat(websocket: WebSocket, room: str, pubsub: PubSubManagerDep) -> None:
     """WebSocket chat room backed by Redis Pub/Sub.
 
     Connect: ``ws://localhost:8000/ws/chat/lobby``
     """
     await websocket.accept()
-    redis = _get_pool_state(websocket.app).get_async_client()
-    pubsub = PubSubManager(redis)
     channel = f"chat:{room}"
     await pubsub.subscribe(channel)
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -21,18 +21,22 @@ if _src not in sys.path:
 
 from typing import Annotated
 
-from fastapi import Depends, FastAPI
+import anyio
+from fastapi import Depends, FastAPI, WebSocket
 
 from redis_fastapi import (
     AsyncRedisDep,
     CacheBackendDep,
     FastAPIRedis,
+    PubSubManager,
+    PubSubManagerDep,
     cache,
     cache_evict,
     default_key_builder,
     get_settings,
 )
 from redis_fastapi.config import RedisSettings
+from redis_fastapi.deps import _get_pool_state
 
 app = FastAPI(
     title="fastapi-redis-sdk demo",
@@ -127,3 +131,40 @@ async def delete_item(item_id: int, cache: CacheBackendDep) -> dict[str, object]
     """Evict a single item from the cache."""
     deleted = await cache.delete(f"item:{item_id}", eviction_group="items")
     return {"id": item_id, "deleted": deleted}
+
+
+@app.post("/notify")
+async def notify(message: str, pubsub: PubSubManagerDep) -> dict[str, int]:
+    """Publish a message to the ``notifications`` channel."""
+    count = await pubsub.publish("notifications", message)
+    return {"subscribers": count}
+
+
+@app.websocket("/ws/chat/{room}")
+async def chat(websocket: WebSocket, room: str) -> None:
+    """WebSocket chat room backed by Redis Pub/Sub.
+
+    Connect: ``ws://localhost:8000/ws/chat/lobby``
+    """
+    await websocket.accept()
+    redis = _get_pool_state(websocket.app).get_async_client()
+    pubsub = PubSubManager(redis)
+    channel = f"chat:{room}"
+    await pubsub.subscribe(channel)
+
+    async def _send() -> None:
+        async for message in pubsub.listen():
+            await websocket.send_text(message["data"].decode())
+
+    async def _receive() -> None:
+        async for data in websocket.iter_text():
+            await pubsub.publish(channel, data)
+
+    try:
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_send)
+            tg.start_soon(_receive)
+    except Exception:
+        pass
+    finally:
+        await pubsub.close()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - User Guide:
     - Architecture: guide/architecture.md
     - Caching: guide/caching.md
+    - Pub/Sub: guide/pubsub.md
     - Configuration: guide/configuration.md
     - Benchmarks: guide/benchmarks.md
   - API Reference:

--- a/src/redis_fastapi/__init__.py
+++ b/src/redis_fastapi/__init__.py
@@ -15,12 +15,15 @@ from redis_fastapi.config import RedisSettings, get_settings
 from redis_fastapi.deps import (
     AsyncRedisDep,
     CacheBackendDep,
+    PubSubManagerDep,
     SyncCacheBackendDep,
     get_async_redis,
     get_cache_backend,
+    get_pubsub_manager,
     get_sync_cache_backend,
 )
 from redis_fastapi.lifespan import redis_lifespan
+from redis_fastapi.pubsub import PubSubManager
 from redis_fastapi.setup import FastAPIRedis
 from redis_fastapi.telemetry import disable_telemetry, enable_telemetry
 from redis_fastapi.types import (
@@ -39,6 +42,8 @@ __all__ = [
     "JsonCoder",
     "KeyBuilder",
     "FastAPIRedis",
+    "PubSubManager",
+    "PubSubManagerDep",
     "RedisSettings",
     "SyncCacheBackend",
     "SyncCacheBackendDep",
@@ -51,6 +56,7 @@ __all__ = [
     "enable_telemetry",
     "get_async_redis",
     "get_cache_backend",
+    "get_pubsub_manager",
     "get_settings",
     "get_sync_cache_backend",
     "pydantic_model_coder",

--- a/src/redis_fastapi/deps.py
+++ b/src/redis_fastapi/deps.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Annotated, TypeAlias
 
 if TYPE_CHECKING:
     from redis_fastapi.cache_backend import CacheBackend, SyncCacheBackend
+    from redis_fastapi.pubsub import PubSubManager
 
 from fastapi import Depends, FastAPI, Request
 from redis.asyncio import ConnectionPool as AsyncConnectionPool
@@ -138,6 +139,26 @@ async def get_sync_cache_backend(request: Request) -> SyncCacheBackend:
     return SyncCacheBackend(backend)
 
 
+async def get_pubsub_manager(
+    redis: AsyncClient = Depends(get_async_redis),
+) -> PubSubManager:
+    """Return a :class:`PubSubManager` backed by the shared async pool.
+
+    Use for publishing messages from HTTP endpoints.  For WebSocket
+    endpoints, construct ``PubSubManager`` directly::
+
+        from redis_fastapi import PubSubManager
+        from redis_fastapi.deps import _get_pool_state
+
+        redis = _get_pool_state(websocket.app).get_async_client()
+        pubsub = PubSubManager(redis)
+    """
+    from redis_fastapi.pubsub import PubSubManager  # noqa: WPS433
+
+    return PubSubManager(redis)
+
+
 AsyncRedisDep = Annotated[AsyncClient, Depends(get_async_redis)]
 CacheBackendDep = Annotated["CacheBackend", Depends(get_cache_backend)]
 SyncCacheBackendDep = Annotated["SyncCacheBackend", Depends(get_sync_cache_backend)]
+PubSubManagerDep = Annotated["PubSubManager", Depends(get_pubsub_manager)]

--- a/src/redis_fastapi/deps.py
+++ b/src/redis_fastapi/deps.py
@@ -9,10 +9,11 @@ if TYPE_CHECKING:
     from redis_fastapi.cache_backend import CacheBackend, SyncCacheBackend
     from redis_fastapi.pubsub import PubSubManager
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI
 from redis.asyncio import ConnectionPool as AsyncConnectionPool
 from redis.asyncio import Redis as AsyncRedis
 from redis.asyncio.cluster import RedisCluster as AsyncRedisCluster
+from starlette.requests import HTTPConnection, Request
 
 from redis_fastapi.config import get_settings
 
@@ -104,8 +105,12 @@ def _get_pool_state(app: FastAPI) -> _PoolState:
     return state
 
 
-async def get_async_redis(request: Request) -> AsyncClient:
+async def get_async_redis(connection: HTTPConnection) -> AsyncClient:
     """Return an async Redis client backed by the shared connection pool.
+
+    Accepts both HTTP ``Request`` and ``WebSocket`` instances (both
+    inherit from ``HTTPConnection``), so this dependency works in
+    HTTP endpoints and WebSocket handlers alike.
 
     Returns a cached client instance - the same wrapper is reused
     across calls to avoid per-request overhead.
@@ -115,7 +120,7 @@ async def get_async_redis(request: Request) -> AsyncClient:
     Raises:
         RuntimeError: If no lifespan has initialized the pool.
     """
-    return _get_pool_state(request.app).get_async_client()
+    return _get_pool_state(connection.app).get_async_client()
 
 
 async def get_cache_backend(request: Request) -> CacheBackend:
@@ -144,14 +149,9 @@ async def get_pubsub_manager(
 ) -> PubSubManager:
     """Return a :class:`PubSubManager` backed by the shared async pool.
 
-    Use for publishing messages from HTTP endpoints.  For WebSocket
-    endpoints, construct ``PubSubManager`` directly::
-
-        from redis_fastapi import PubSubManager
-        from redis_fastapi.deps import _get_pool_state
-
-        redis = _get_pool_state(websocket.app).get_async_client()
-        pubsub = PubSubManager(redis)
+    Works in both HTTP endpoints and WebSocket handlers because
+    ``get_async_redis`` accepts ``HTTPConnection``, the common base
+    of ``Request`` and ``WebSocket``.
     """
     from redis_fastapi.pubsub import PubSubManager  # noqa: WPS433
 

--- a/src/redis_fastapi/pubsub.py
+++ b/src/redis_fastapi/pubsub.py
@@ -1,0 +1,151 @@
+"""Redis Pub/Sub manager for real-time messaging.
+
+Provides a :class:`PubSubManager` that wraps Redis Pub/Sub operations
+for use in WebSocket endpoints and background tasks.  Each instance
+uses a dedicated PubSub connection from the shared async pool.
+
+Usage with dependency injection (HTTP)::
+
+    from redis_fastapi import PubSubManagerDep
+
+    @app.get("/publish")
+    async def publish(pubsub: PubSubManagerDep):
+        await pubsub.publish("channel", "hello")
+
+Usage in WebSocket endpoints::
+
+    from redis_fastapi import PubSubManager
+    from redis_fastapi.deps import _get_pool_state
+
+    @app.websocket("/ws/{room}")
+    async def chat(websocket: WebSocket):
+        redis = _get_pool_state(websocket.app).get_async_client()
+        pubsub = PubSubManager(redis)
+        await pubsub.subscribe(f"room:{room}")
+        async for message in pubsub.listen():
+            await websocket.send_text(message["data"])
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from redis.exceptions import RedisError
+
+from redis_fastapi.deps import AsyncClient
+from redis_fastapi.telemetry import cache_span, record_pubsub_publish
+
+logger = logging.getLogger(__name__)
+
+
+class PubSubManager:
+    """Manages Redis Pub/Sub connections for real-time messaging.
+
+    Each instance wraps a dedicated PubSub connection obtained from
+    the shared pool.  Call :meth:`subscribe` to join channels, then
+    iterate :meth:`listen` to receive messages.
+
+    Args:
+        redis: An async Redis client (standalone or cluster).
+    """
+
+    def __init__(self, redis: AsyncClient) -> None:
+        self._redis = redis
+        self._pubsub: Any = None
+
+    async def subscribe(self, *channels: str) -> None:
+        """Subscribe to one or more Redis channels.
+
+        Creates the underlying PubSub connection on first call.
+        Subsequent calls add channels to the existing subscription.
+
+        Args:
+            *channels: One or more channel names to subscribe to.
+        """
+        ps = await self._get_or_create_pubsub()
+        await ps.subscribe(*channels)
+
+    async def unsubscribe(self, *channels: str) -> None:
+        """Unsubscribe from one or more Redis channels.
+
+        Safe to call before :meth:`subscribe`; no-op when the
+        PubSub connection has not been created.
+
+        Args:
+            *channels: One or more channel names to unsubscribe from.
+        """
+        if self._pubsub is None:
+            return
+        await self._pubsub.unsubscribe(*channels)
+
+    async def publish(self, channel: str, message: str) -> int:
+        """Publish a message to a Redis channel.
+
+        Args:
+            channel: The target channel name.
+            message: The message string to publish.
+
+        Returns:
+            Number of subscribers that received the message, or ``0``
+            on error.
+        """
+        with cache_span(
+            "pubsub.publish",
+            attributes={"pubsub.channel": channel},
+        ):
+            try:
+                count = await self._redis.publish(channel, message)
+                record_pubsub_publish(channel=channel, subscribers=count)
+                return count
+            except (RedisError, OSError):
+                logger.warning(
+                    "Error publishing to channel '%s'", channel, exc_info=True
+                )
+                return 0
+
+    async def listen(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield messages from all subscribed channels.
+
+        Each yielded dict follows redis-py's PubSub message format::
+
+            {
+                "type": "message",
+                "pattern": None,
+                "channel": b"channel_name",
+                "data": b"message_content",
+            }
+
+        Only ``message``-type events are yielded; subscription
+        confirmation and other system events are filtered out.
+
+        Yields:
+            Raw PubSub message dicts.
+        """
+        ps = await self._get_or_create_pubsub()
+        async for message in ps.listen():
+            if message["type"] == "message":
+                yield message
+
+    async def close(self) -> None:
+        """Unsubscribe all channels and close the PubSub connection.
+
+        Safe to call multiple times.  No-op when already closed or
+        never connected.
+        """
+        if self._pubsub is None:
+            return
+        try:
+            await self._pubsub.unsubscribe()
+            await self._pubsub.aclose()
+        except (RedisError, OSError):
+            logger.warning("Error closing PubSub connection", exc_info=True)
+        finally:
+            self._pubsub = None
+
+    async def _get_or_create_pubsub(self) -> Any:
+        """Return the PubSub connection, creating it lazily."""
+        if self._pubsub is None:
+            self._pubsub = self._redis.pubsub()
+        return self._pubsub

--- a/src/redis_fastapi/telemetry.py
+++ b/src/redis_fastapi/telemetry.py
@@ -48,6 +48,9 @@ class _OTelState:
     cache_writes: Any = None
     cache_latency: Any = None
 
+    # PubSub metric instruments
+    pubsub_messages: Any = None
+
 
 _state = _OTelState()
 
@@ -105,6 +108,12 @@ def enable_telemetry() -> None:
         name="redis_fastapi.cache.latency",
         description="Cache operation duration",
         unit="s",
+    )
+
+    _state.pubsub_messages = _state.meter.create_counter(
+        name="redis_fastapi.pubsub.messages",
+        description="PubSub messages published",
+        unit="1",
     )
 
     _state.enabled = True
@@ -221,6 +230,22 @@ def record_cache_latency(
         )
     except Exception:
         logger.debug("Error recording cache latency metric", exc_info=True)
+
+
+def record_pubsub_publish(
+    *,
+    channel: str,
+    subscribers: int = 0,
+) -> None:
+    """Record a PubSub message publication."""
+    if not _state.enabled or _state.pubsub_messages is None:
+        return
+    try:
+        _state.pubsub_messages.add(
+            1, {"channel": channel, "subscribers": str(subscribers)}
+        )
+    except Exception:
+        logger.debug("Error recording pubsub publish metric", exc_info=True)
 
 
 @contextlib.contextmanager

--- a/tests/integration/test_pubsub.py
+++ b/tests/integration/test_pubsub.py
@@ -1,0 +1,102 @@
+"""Integration tests for PubSubManager with a real Redis server."""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+
+from redis_fastapi.pubsub import PubSubManager
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        True, reason="Requires a running Redis server — run with --runintegration"
+    ),
+]
+
+
+@pytest.mark.integration
+class TestPubSubIntegration:
+    """PubSubManager end-to-end with a real Redis server."""
+
+    async def test_cross_connection_pubsub(
+        self,
+        real_async_redis: any,
+        test_prefix: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """Two PubSubManager instances on the same Redis communicate."""
+        pub_a = PubSubManager(real_async_redis)
+        pub_b = PubSubManager(real_async_redis)
+        channel = f"{test_prefix}:bridge"
+
+        await pub_a.subscribe(channel)
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pub_b.publish(channel, "from-b")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pub_a.listen():
+                assert message["data"] == b"from-b"
+                break
+
+        await pub_a.close()
+        await pub_b.close()
+
+    async def test_publish_subscriber_count(
+        self,
+        real_async_redis: any,
+        test_prefix: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """publish() returns the number of subscribers."""
+        pub = PubSubManager(real_async_redis)
+        channel = f"{test_prefix}:count"
+
+        sub = PubSubManager(real_async_redis)
+        await sub.subscribe(channel)
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for _message in sub.listen():
+                break
+
+        count = await pub.publish(channel, "hi")
+        assert count >= 1
+        await pub.close()
+        await sub.close()
+
+    async def test_unsubscribe_stops_messages(
+        self,
+        real_async_redis: any,
+        test_prefix: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        """After unsubscribe, no more messages arrive on that channel."""
+        pub = PubSubManager(real_async_redis)
+        sub = PubSubManager(real_async_redis)
+        channel = f"{test_prefix}:unsub"
+
+        await sub.subscribe(channel)
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pub.publish(channel, "first")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in sub.listen():
+                assert message["data"] == b"first"
+                break
+
+        await sub.unsubscribe(channel)
+
+        await pub.publish(channel, "second")
+
+        # No more messages should arrive — just verify no crash
+        await anyio.sleep(0.1)
+
+        await pub.close()
+        await sub.close()

--- a/tests/unit/test_pubsub.py
+++ b/tests/unit/test_pubsub.py
@@ -1,0 +1,438 @@
+"""Unit tests for PubSubManager with fakeredis."""
+
+from __future__ import annotations
+
+import anyio
+import asyncio
+import fakeredis.aioredis
+import gc
+import pytest
+
+from redis_fastapi.pubsub import PubSubManager
+
+
+@pytest.mark.unit
+class TestPubSubManager:
+    """Core PubSubManager lifecycle: subscribe, listen, publish, close."""
+
+    async def test_subscribe_and_listen(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("test:ch")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("test:ch", "hello")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"hello"
+                break
+
+        await pubsub.close()
+
+    async def test_multiple_channels(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:a", "ch:b")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:a", "msg-a")
+            await pubsub.publish("ch:b", "msg-b")
+
+        received: list[str] = []
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                received.append(message["data"])
+                if len(received) == 2:
+                    break
+
+        assert b"msg-a" in received
+        assert b"msg-b" in received
+        await pubsub.close()
+
+    async def test_publish_returns_subscriber_count(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pub_a = PubSubManager(fake)
+        pub_b = PubSubManager(fake)
+        await pub_b.subscribe("test:ch")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            count = await pub_a.publish("test:ch", "hello")
+            assert count == 1
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for _message in pub_b.listen():
+                break
+
+        await pub_a.close()
+        await pub_b.close()
+
+    async def test_unsubscribe(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:a", "ch:b")
+        await pubsub.unsubscribe("ch:a")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:a", "a-only")
+            await pubsub.publish("ch:b", "b-only")
+
+        received: list[str] = []
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                received.append(message["data"])
+                if len(received) == 1:
+                    break
+
+        assert received == [b"b-only"]
+        await pubsub.close()
+
+    async def test_close_idempotent(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.close()
+        await pubsub.close()
+
+    async def test_unsubscribe_before_connect(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.unsubscribe("ch")  # should not raise
+
+    async def test_listen_yields_only_message_type(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("test:ch")
+
+        events: list[str] = []
+        async with anyio.create_task_group() as tg:
+
+            async def _publish() -> None:
+                await anyio.sleep(0.05)
+                await pubsub.publish("test:ch", "hello")
+
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                events.append(message["type"])
+                break
+
+        assert events == ["message"]
+        await pubsub.close()
+
+    async def test_di_pubsub_manager_dep(
+        self, fake_async_redis: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        """Verify PubSubManager works with get_async_redis client."""
+        from redis_fastapi import PubSubManager
+
+        pubsub = PubSubManager(fake_async_redis)
+        await pubsub.subscribe("test:di")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("test:di", "from-di")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"from-di"
+                break
+
+        await pubsub.close()
+
+
+@pytest.mark.unit
+class TestPubSubErrorHandling:
+    """PubSubManager gracefully handles Redis errors."""
+
+    async def test_publish_error_returns_zero(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        count = await pubsub.publish("ch", "data")
+        assert count == 0
+        await pubsub.close()
+
+
+@pytest.mark.unit
+class TestPubSubEdgeCases:
+    """Edge cases: empty channels, binary data, reconnection, etc."""
+
+    async def test_empty_channel_name(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("")
+        await pubsub.publish("", "empty-ch")
+        await pubsub.close()
+
+    async def test_unicode_message(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:unicode")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:unicode", "héllo wörld 🎉")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert isinstance(message["data"], bytes)
+                assert message["data"] == "héllo wörld 🎉".encode()
+                break
+        await pubsub.close()
+
+    async def test_utf8_message_with_special_chars(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:utf8")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:utf8", "tab\there\nnewline")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"tab\there\nnewline"
+                break
+        await pubsub.close()
+
+    async def test_subscribe_after_close_reconnects(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:first")
+        await pubsub.close()
+
+        await pubsub.subscribe("ch:second")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:second", "after-reconnect")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"after-reconnect"
+                break
+        await pubsub.close()
+
+    async def test_close_then_publish_no_crash(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.close()
+        count = await pubsub.publish("ch", "after-close")
+        assert count == 0
+        await pubsub.close()
+
+    async def test_long_channel_name(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        long_ch = "ch:" + "a" * 500
+        await pubsub.subscribe(long_ch)
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish(long_ch, "long-channel")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"long-channel"
+                break
+        await pubsub.close()
+
+    async def test_large_message(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:large")
+        large_msg = "x" * 100_000
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:large", large_msg)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert len(message["data"]) == 100_000
+                break
+        await pubsub.close()
+
+    async def test_rapid_publish_burst(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:burst")
+
+        async def _publish_burst() -> None:
+            await anyio.sleep(0.05)
+            for i in range(20):
+                await pubsub.publish("ch:burst", str(i))
+
+        received: list[int] = []
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish_burst)
+            async for message in pubsub.listen():
+                received.append(int(message["data"]))
+                if len(received) == 20:
+                    break
+        assert received == list(range(20))
+        await pubsub.close()
+
+    async def test_multiple_concurrent_subscribers(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        sub_a = PubSubManager(fake)
+        sub_b = PubSubManager(fake)
+        pub = PubSubManager(fake)
+        await sub_a.subscribe("ch:multi")
+        await sub_b.subscribe("ch:multi")
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pub.publish("ch:multi", "to-all")
+
+        results: list[str] = []
+
+        async def _listen(sub: PubSubManager, label: str) -> None:
+            async for _message in sub.listen():
+                results.append(label)
+                break
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            tg.start_soon(_listen, sub_a, "a")
+            tg.start_soon(_listen, sub_b, "b")
+
+        assert "a" in results
+        assert "b" in results
+        assert len(results) == 2
+        await sub_a.close()
+        await sub_b.close()
+        await pub.close()
+
+    async def test_channel_name_with_special_chars(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        special_ch = "ch:spaces and :colons:and/slashes"
+        await pubsub.subscribe(special_ch)
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish(special_ch, "special")
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert message["data"] == b"special"
+                break
+        await pubsub.close()
+
+    async def test_double_subscribe_same_channel(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:dup")
+        await pubsub.subscribe("ch:dup")  # second subscribe should be idempotent
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:dup", "deduped")
+
+        received = 0
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for _message in pubsub.listen():
+                received += 1
+                break
+
+        assert received == 1
+        await pubsub.close()
+
+    async def test_unsubscribe_all_channels(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:a", "ch:b", "ch:c")
+        await pubsub.unsubscribe()
+        # After unsubscribing all, listen should not yield
+        await pubsub.close()
+
+    async def test_memory_safety_large_payload(self) -> None:
+        fake = fakeredis.aioredis.FakeRedis()
+        pubsub = PubSubManager(fake)
+        await pubsub.subscribe("ch:big")
+        huge = "z" * 1_000_000  # 1 MB string
+
+        async def _publish() -> None:
+            await anyio.sleep(0.05)
+            await pubsub.publish("ch:big", huge)
+
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(_publish)
+            async for message in pubsub.listen():
+                assert len(message["data"]) == 1_000_000
+                break
+        await pubsub.close()
+
+
+@pytest.mark.unit
+class TestPubSubMemory:
+    """Memory leak and reference cycle tests."""
+
+    def test_no_memory_leak_after_close(self) -> None:
+        """PubSubManager is garbage collected after close() and ref removal.
+
+        Creates a manager, subscribes, closes, then verifies via weakref
+        that the object is collected once all strong references are gone.
+        The check runs outside ``asyncio.run()`` so the coroutine frame
+        does not keep the object alive.
+        """
+        import weakref
+
+        fake = fakeredis.aioredis.FakeRedis()
+
+        async def lifecycle() -> weakref.ref:
+            m = PubSubManager(fake)
+            await m.subscribe("mem:leak")
+            await m.close()
+            return weakref.ref(m)
+
+        ref = asyncio.run(lifecycle())
+
+        gc.collect()
+        gc.collect()
+        gc.collect()
+
+        assert ref() is None, (
+            "PubSubManager was not garbage collected — possible reference cycle. "
+            f"Object: {ref()}"
+        )
+
+    def test_multiple_instances_collected(self) -> None:
+        """Many PubSubManager instances are all collectable."""
+        import weakref
+
+        async def bulk() -> list[weakref.ref]:
+            refs = []
+            for i in range(50):
+                fake = fakeredis.aioredis.FakeRedis()
+                m = PubSubManager(fake)
+                await m.subscribe(f"bulk:ch:{i}")
+                await m.close()
+                refs.append(weakref.ref(m))
+            return refs
+
+        refs = asyncio.run(bulk())
+        gc.collect()
+        gc.collect()
+        gc.collect()
+
+        alive = [r for r in refs if r() is not None]
+        assert len(alive) == 0, (
+            f"{len(alive)} out of {len(refs)} PubSubManager instances "
+            "were not garbage collected"
+        )

--- a/tests/unit/test_pubsub.py
+++ b/tests/unit/test_pubsub.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import anyio
 import asyncio
-import fakeredis.aioredis
 import gc
+
+import anyio
+import fakeredis.aioredis
 import pytest
 
 from redis_fastapi.pubsub import PubSubManager


### PR DESCRIPTION
**Implement Redis-backed WebSocket Pub/Sub helpers (Issue #24)**

5 commits:

**feat: add PubSubManager for Redis Pub/Sub messaging**
`pubsub.py`, `__init__.py`, `deps.py`, `telemetry.py`

PubSubManager with subscribe/listen/publish/close. FastAPI DI via `get_pubsub_manager` (sub-dependency on `Depends(get_async_redis)`). `record_pubsub_publish` telemetry counter.

**test: add 25 PubSub unit tests**
`tests/unit/test_pubsub.py`

Core lifecycle, 13 edge cases, memory leak via weakref, DI integration.

**test: add PubSub integration tests**
`tests/integration/test_pubsub.py`

Cross-connection bridge, subscriber count, unsub isolation (requires real Redis).

**docs: add PubSub user guide and API reference**
`docs/guide/pubsub.md`, `docs/api/reference.md`, `mkdocs.yml`

Guide with WebSocket examples, connection pool limitation note, DI override chains.

**examples: add PubSub WebSocket chat and notify endpoint**
`examples/main.py`

`/notify` HTTP publish and `/ws/chat/{room}` WebSocket broadcast loop.

**Design decisions**

- `get_pubsub_manager` uses `Depends(get_async_redis)` instead of calling `get_async_redis` directly, so callers can override the Redis client without re-registering the PubSub provider.
- `listen()` filters system events and yields only `message`-type events.
- Each `subscribe()` call consumes one dedicated pool connection (inherent Redis Pub/Sub limitation), documented in the guide.
- No new middleware or lifespan changes needed; Pub/Sub reuses the existing shared pool.

Closes #24