### PR TITLE
feat: allow injecting a custom connection pool via pool_factory

### DIFF
--- a/src/redis_fastapi/lifespan.py
+++ b/src/redis_fastapi/lifespan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from inspect import isawaitable
 from typing import Any
 
 from fastapi import FastAPI
@@ -109,6 +110,18 @@ async def redis_lifespan(app: FastAPI) -> AsyncIterator[None]:
     When ``settings.otel_redis_enabled`` is ``True``, also initializes
     redis-py's native OpenTelemetry integration on startup and shuts it
     down on teardown.
+
+    **Custom connection pool.** When ``app.state.redis_pool_factory`` is set
+    (directly, or via ``FastAPIRedis(app).lifespan(pool_factory=...)``), the
+    standalone pool is obtained from that zero-argument callable instead of
+    being built from environment settings. The callable may be sync or
+    async, and must return a ``redis.asyncio.ConnectionPool`` (a
+    ``SentinelConnectionPool`` works too — that is the main use case:
+    Sentinel-managed or vault-credentialed deployments whose connection
+    parameters cannot be expressed as static environment variables). The
+    lifespan takes ownership of the returned pool and closes it on
+    shutdown. Not supported in cluster mode (``settings.cluster``), which
+    raises ``ValueError`` to keep the override explicit.
     """
     settings = get_settings()
 
@@ -126,8 +139,19 @@ async def redis_lifespan(app: FastAPI) -> AsyncIterator[None]:
     ps = _PoolState()
     app.state._redis = ps
 
+    pool_factory = getattr(app.state, "redis_pool_factory", None)
     if settings.cluster:
+        if pool_factory is not None:
+            raise ValueError(
+                "redis_pool_factory is not supported in cluster mode — "
+                "unset REDIS_CLUSTER or drop the factory"
+            )
         ps.async_cluster = _PoolState.build_async_cluster()
+    elif pool_factory is not None:
+        pool = pool_factory()
+        if isawaitable(pool):
+            pool = await pool
+        ps.async_pool = pool
     else:
         ps.async_pool = _PoolState.build_async_pool()
 

--- a/src/redis_fastapi/setup.py
+++ b/src/redis_fastapi/setup.py
@@ -55,7 +55,7 @@ class FastAPIRedis:
         """Check whether *cls* is already registered in ``app.user_middleware``."""
         return any(m.cls is cls for m in self._app.user_middleware)  # type: ignore[comparison-overlap]
 
-    def lifespan(self) -> FastAPIRedis:
+    def lifespan(self, *, pool_factory: Any = None) -> FastAPIRedis:
         """Manage Redis connection pools across the application lifecycle.
 
         Wraps the existing ``app.router.lifespan_context`` so that Redis
@@ -65,8 +65,21 @@ class FastAPIRedis:
         Supports both standalone and OSS Cluster modes based on
         ``get_settings().cluster``.
 
+        Args:
+            pool_factory: Optional zero-argument callable (sync or async)
+                returning the ``redis.asyncio.ConnectionPool`` to use
+                instead of one built from environment settings. Lets
+                deployments whose connection parameters are not static env
+                vars — Sentinel-managed clusters, secret-manager-issued
+                passwords — supply their own pool while keeping every
+                caching and rate-limiting dependency unchanged. The
+                lifespan owns the returned pool and closes it on shutdown.
+                Not supported in cluster mode.
+
         Calling this method more than once on the same app is a no-op.
         """
+        if pool_factory is not None:
+            self._app.state.redis_pool_factory = pool_factory
         if getattr(self._app.router.lifespan_context, "_redis_lifespan", False):
             return self
 

--- a/tests/unit/test_pool_injection.py
+++ b/tests/unit/test_pool_injection.py
@@ -1,0 +1,90 @@
+"""Tests for custom pool injection (``pool_factory`` / ``redis_pool_factory``).
+
+Deployments whose connection parameters are not static environment variables
+(Sentinel-managed masters, secret-manager-issued passwords) need to hand the
+lifespan a pool they built themselves. These tests assert the three contract
+points: the factory's pool is the one dependencies resolve to, an async
+factory is awaited, and cluster mode refuses the override explicitly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from redis.asyncio import ConnectionPool as AsyncConnectionPool
+
+from redis_fastapi import FastAPIRedis
+from redis_fastapi.deps import get_async_redis
+from redis_fastapi.lifespan import redis_lifespan
+
+
+def _make_pool() -> AsyncConnectionPool:
+    # Never connected in these tests — identity is what matters.
+    return AsyncConnectionPool.from_url("redis://injection-test:6379/5")
+
+
+@pytest.mark.asyncio
+async def test_sync_factory_pool_is_used() -> None:
+    pool = _make_pool()
+    app = FastAPI()
+    FastAPIRedis(app).lifespan(pool_factory=lambda: pool)
+
+    async with app.router.lifespan_context(app):
+        state = app.state._redis
+        assert state.async_pool is pool
+        client = state.get_async_client()
+        assert client.connection_pool is pool
+
+
+@pytest.mark.asyncio
+async def test_async_factory_is_awaited() -> None:
+    pool = _make_pool()
+
+    async def factory() -> AsyncConnectionPool:
+        return pool
+
+    app = FastAPI()
+    FastAPIRedis(app).lifespan(pool_factory=factory)
+
+    async with app.router.lifespan_context(app):
+        assert app.state._redis.async_pool is pool
+
+
+@pytest.mark.asyncio
+async def test_state_attribute_alone_is_honoured() -> None:
+    """Setting ``app.state.redis_pool_factory`` directly (the plain
+    ``FastAPI(lifespan=redis_lifespan)`` path) works without the builder."""
+    pool = _make_pool()
+    app = FastAPI(lifespan=redis_lifespan)
+    app.state.redis_pool_factory = lambda: pool
+
+    async with app.router.lifespan_context(app):
+        assert app.state._redis.async_pool is pool
+
+
+@pytest.mark.asyncio
+async def test_cluster_mode_refuses_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REDIS_CLUSTER", "true")
+    from redis_fastapi.config import get_settings
+
+    get_settings.cache_clear()
+    try:
+        app = FastAPI()
+        FastAPIRedis(app).lifespan(pool_factory=_make_pool)
+        with pytest.raises(ValueError, match="cluster mode"):
+            async with app.router.lifespan_context(app):
+                pass  # pragma: no cover — must not be reached
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_no_factory_builds_from_settings() -> None:
+    """Regression guard: without a factory the settings-built pool remains."""
+    app = FastAPI()
+    FastAPIRedis(app).lifespan()
+
+    async with app.router.lifespan_context(app):
+        assert app.state._redis.async_pool is not None


### PR DESCRIPTION
## Motivation

Deployments whose connection parameters are not static environment variables cannot use the settings-built pool:

- **Sentinel-managed masters** — the pool that follows failover is a `SentinelConnectionPool` built from `Sentinel.master_for(...)`, which no `REDIS_URL`/KV setting can express.
- **Secret-manager-issued passwords** — the credential is fetched at startup (Vault, AWS SM, etc.), not present in the environment.

Today the only way in is reaching into the private `_PoolState` and assigning `app.state._redis` from a custom lifespan — which works, but pins consumers to internals (we are running exactly that in production against 0.8.0 and would like to stop).

## Design

One public seam, no behavior change for existing users:

```python
FastAPIRedis(app).lifespan(pool_factory=make_my_pool)   # sync or async callable
```

or, for plain `FastAPI(lifespan=redis_lifespan)` users:

```python
app.state.redis_pool_factory = make_my_pool
```

- The factory is a zero-argument sync **or async** callable returning the `redis.asyncio.ConnectionPool` to use (async matters: fetching a credential at startup is I/O).
- The lifespan **owns** the returned pool and closes it on shutdown, identical to the settings-built one.
- Cluster mode raises `ValueError` rather than silently ignoring the override.
- Every caching / rate-limiting dependency is untouched — they already resolve through the pool state.

## Tests

`tests/unit/test_pool_injection.py`: sync factory, async factory, state-attribute path, cluster refusal, and a regression guard for the default settings-built path. Full unit run: 108 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)