### PR TITLE
Rate limiting: remove `REDIS_RATE_LIMIT_TRUST_PROXY`, handle unidentifiable clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Idiomatic Redis integration for FastAPI - connection management and DI-based cac
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v0.json)](https://astral.sh/ruff)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/fastapi-redis-sdk)](https://pypistats.org/packages/fastapi-redis-sdk)
 [![codecov](https://codecov.io/gh/redis/fastapi-redis-sdk/branch/main/graph/badge.svg?token=yenl5fzxxr)](https://codecov.io/gh/redis/fastapi-redis-sdk)
 [![Guide](https://img.shields.io/badge/mkdocs-guide-526CFE?logo=materialformkdocs&logoColor=white)](https://redis.github.io/fastapi-redis-sdk/)
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -283,7 +283,15 @@ def ip_identifier(request: Request) -> str          # default identifier (client
 Identifier = Callable[[Request], str | Awaitable[str]]
 ```
 
-An `Identifier` returns the **client identity** segment of the counter key (e.g. an IP or user id) - the backend adds `scope` and `prefix`. Pass any callable as `identifier=` to key by user, API key, or tenant. `ip_identifier` honours `REDIS_RATE_LIMIT_TRUST_PROXY` when deriving the client IP.
+An `Identifier` returns the **client identity** segment of the counter key (e.g. an IP or user id) - the backend adds `scope` and `prefix`. Pass any callable as `identifier=` to key by user, API key, or tenant. `ip_identifier` returns `request.client.host` and never parses `X-Forwarded-For` - configure proxy headers at the ASGI server (Uvicorn `--proxy-headers`), or supply your own identifier. See [Behind a proxy](../guide/rate-limiting.md#behind-a-proxy).
+
+### `CannotIdentifyClient`
+
+```python
+class CannotIdentifyClient(Exception)
+```
+
+Raise from an `Identifier` that cannot tell callers apart. The limiter then treats the check like a Redis outage: `RateLimitResult.degraded` is `True`, the `error` metric is recorded, and `fail_closed` decides whether the request passes uncounted or gets a 429 - so the request is never counted against a shared placeholder bucket. `ip_identifier` raises it when the ASGI scope has no client address. See [Callers that cannot be identified](../guide/rate-limiting.md#callers-that-cannot-be-identified).
 
 ### `Rate` / `parse_rate()`
 

--- a/docs/guide/rate-limiting.md
+++ b/docs/guide/rate-limiting.md
@@ -166,7 +166,7 @@ share a counter*, the other *which clients share a counter*:
 |--------------|--------------------|--------------------------------------------------------------------|-----------------------------------|
 | `prefix`     | which app          | `REDIS_PREFIX` (app-wide)                                          | `redis:fastapi:ratelimit`         |
 | `scope`      | which **routes**   | `scope=` on `rate_limit()`                                         | the matched route template        |
-| `identifier` | which **clients**  | `identifier=` (and `REDIS_RATE_LIMIT_TRUST_PROXY` for the default) | client IP via `ip_identifier`     |
+| `identifier` | which **clients**  | `identifier=`                                                      | client IP via `ip_identifier`     |
 
 Two requests hit the **same** counter only when all three match.  Examples for
 client `1.2.3.4` on route `/items/{id}` (the resulting counter key is shown as a
@@ -224,6 +224,11 @@ def header_identifier(header: str) -> Identifier:
 tenant_id = header_identifier("X-Tenant-ID")   # an Identifier
 ```
 
+If your identifier cannot name the caller at all, raise
+[`CannotIdentifyClient`](#callers-that-cannot-be-identified) rather than
+returning a placeholder - a placeholder makes every such request share one
+counter.
+
 !!! note "Partition the counter, don't vary the limit"
     A custom identifier only *partitions* the counter - every client it
     distinguishes still gets the **same** limit, counted separately.  Selecting a
@@ -232,13 +237,89 @@ tenant_id = header_identifier("X-Tenant-ID")   # an Identifier
 
 ### Behind a proxy
 
-By default the client IP is `request.client.host`.  When the app runs behind a
-trusted proxy or load balancer, enable `REDIS_RATE_LIMIT_TRUST_PROXY=true` so the
-first hop of `X-Forwarded-For` is used instead.
+`ip_identifier` returns `request.client.host` - the immediate peer from the ASGI
+scope - and **never** reads `X-Forwarded-For`.  Behind a proxy that is the
+load balancer's address, so every client would share one counter unless the
+proxy's real client IP reaches the scope.  Configure that at the **ASGI server**,
+not here.
 
-!!! warning
-    Only trust `X-Forwarded-For` when a proxy you control sets it - clients can
-    otherwise spoof the header to evade limits.
+!!! warning "Why the SDK does not parse `X-Forwarded-For`"
+    `X-Forwarded-For` is set by the client and *appended to* by each hop -
+    nginx's `$proxy_add_x_forwarded_for`, AWS ALB and GCP LB all append rather
+    than overwrite.  So the header's **left-most** entry is whatever the caller
+    typed, even behind a correctly configured proxy.  Keying a limit on it lets
+    any client rotate identities to evade its own limit, or forge a victim's
+    address to exhaust theirs.  Only the ASGI server knows how many hops to
+    trust, so that is where the decision belongs.
+
+#### Uvicorn (and Gunicorn with Uvicorn workers)
+
+Uvicorn's `ProxyHeadersMiddleware` does this correctly: it rewrites
+`scope["client"]` **once** for the whole app, but only when the immediate peer is
+in the trusted list, and it walks `X-Forwarded-For` **right-to-left** to find the
+first hop the list does not cover.  Because Starlette reads `request.client`
+straight from the scope, `ip_identifier` picks up the corrected address with no
+configuration on the SDK side:
+
+```bash
+# Trust one proxy on the same host (the default), then read request.client:
+uvicorn app:main --proxy-headers --forwarded-allow-ips="127.0.0.1"
+
+# Behind a load balancer on the pod network:
+uvicorn app:main --proxy-headers --forwarded-allow-ips="10.0.0.0/8"
+```
+
+The equivalent for Gunicorn with Uvicorn workers is `--forwarded-allow-ips`.
+
+!!! danger "`--forwarded-allow-ips="*"` disables the peer check"
+    A wildcard trusts `X-Forwarded-For` from **any** peer, which restores exactly
+    the spoofing hole described above.  Set the narrowest CIDR that covers your
+    proxies.  If you cannot enumerate them - some managed platforms rotate
+    egress addresses - prefer an identifier keyed on something authenticated (a
+    session, an API key) over an IP you cannot verify.
+
+#### Servers without proxy-header support
+
+Hypercorn, Daphne, Granian, and serverless adapters such as Mangum either handle
+this differently or not at all.  Supply your own `identifier=` and apply the same
+two rules Uvicorn does - **gate on the peer, then walk right-to-left**:
+
+```python
+from ipaddress import ip_address, ip_network
+
+TRUSTED_PROXIES = [ip_network("10.0.0.0/8")]
+
+def _trusted(host: str) -> bool:
+    try:
+        return any(ip_address(host) in net for net in TRUSTED_PROXIES)
+    except ValueError:      # not an IP address at all
+        return False
+
+def proxied_ip_identifier(request) -> str:
+    peer = request.client.host if request.client is not None else ""
+    # 1. Gate: only look at the header when the peer is a proxy we trust.
+    if not _trusted(peer):
+        return peer
+    # 2. Select: right-to-left, the first hop that is not one of our proxies.
+    hops = [h.strip() for h in request.headers.get("X-Forwarded-For", "").split(",")]
+    for hop in reversed(hops):
+        if hop and not _trusted(hop):
+            return hop
+    return peer
+
+@app.get("/items", dependencies=[Depends(rate_limit("100/minute", identifier=proxied_ip_identifier))])
+async def items(): ...
+```
+
+Without the **gate**, a client that reaches the app directly supplies the whole chain.  
+Without **right-to-left**, the left-most entry is caller-controlled even when the gate passes.
+
+!!! tip "CDN headers"
+    Cloudflare's `CF-Connecting-IP`, Fastly's `Fastly-Client-IP`, and similar
+    single-value headers are simpler to consume - one hop, set by the edge - but
+    still need the peer gate, or a client hitting your origin directly can forge
+    them.  Keep them in your own identifier rather than expecting one from the
+    SDK: which header is authoritative is a property of your edge, not of Redis.
 
 ---
 
@@ -568,6 +649,44 @@ Either way the outage stays visible: the check's `RateLimitResult.degraded` is
 rather than as a normal `allowed` / `limited` outcome - so a fail-open spike does
 not silently masquerade as healthy traffic.
 
+### Callers that cannot be identified
+
+A limiter needs to tell callers apart before it can count them.  When the
+identifier cannot, it raises `CannotIdentifyClient` and the check takes the
+**same** fail-open / fail-closed path as a Redis outage: `degraded=True`, an
+`error` metric, allowed-but-uncounted by default, or a 429 under
+`fail_closed=True`.
+
+`ip_identifier` raises it when the ASGI scope carries no client address.
+`scope["client"]` is optional in the ASGI spec, and some serverless adapters
+(Mangum and similar) and test transports leave it unset.
+
+!!! note "Why not fall back to a placeholder identity"
+    Returning something like `"unknown"` would be worse than failing: every
+    request that hit the fallback would share **one** counter, so a `100/minute`
+    limit would cap the *entire application* at 100 requests a minute.  That
+    needs no attacker and no misconfiguration - just a platform that omits
+    `scope["client"]` - and it looks exactly like a working limiter from the
+    outside.  Degrading the check keeps the failure loud and bounded to the
+    requests it affects.
+
+The exception is public, so your own identifiers can use it for the same reason -
+prefer it over pooling every unauthenticated caller into one bucket:
+
+```python
+from redis_fastapi import CannotIdentifyClient
+
+def user_identifier(request) -> str:
+    user = getattr(request.state, "user", None)
+    if user is None:
+        raise CannotIdentifyClient("no authenticated user on the request")
+    return f"user:{user.id}"
+```
+
+If pooling *is* what you want - one shared budget for all anonymous traffic -
+return a constant instead, and size the limit for the whole population rather
+than for one client.
+
 ---
 
 ## 8. Configuration
@@ -581,13 +700,15 @@ mechanism as the caching options - see [Configuration](configuration.md)):
 | `rate_limit_default_window`        | `REDIS_RATE_LIMIT_DEFAULT_WINDOW`  | `60`    | Global window, in seconds.                           |
 | `rate_limit_emit_headers`          | `REDIS_RATE_LIMIT_EMIT_HEADERS`    | `true`  | Emit the `X-RateLimit-*` trio.                       |
 | `rate_limit_ietf_headers`          | `REDIS_RATE_LIMIT_IETF_HEADERS`    | `false` | Also emit IETF `RateLimit` / `RateLimit-Policy`.     |
-| `rate_limit_trust_proxy`           | `REDIS_RATE_LIMIT_TRUST_PROXY`     | `false` | Honour `X-Forwarded-For` for the client IP.          |
 | `rate_limit_fail_closed`           | `REDIS_RATE_LIMIT_FAIL_CLOSED`     | `false` | Reject (vs allow) when Redis is unreachable.         |
+
+There is deliberately **no** proxy-trust setting - see
+[Behind a proxy](#behind-a-proxy) for why that decision belongs to the ASGI
+server, and what to configure instead.
 
 ```bash
 export REDIS_URL=redis://localhost:6379
 export REDIS_RATE_LIMIT_DEFAULT_LIMIT=1000   # >0 enables the global limiter
-export REDIS_RATE_LIMIT_TRUST_PROXY=true
 export REDIS_RATE_LIMIT_IETF_HEADERS=true
 ```
 
@@ -654,8 +775,9 @@ exactly the limit (proving atomicity).
 2. **Start with `rate_limit("N/unit")`** on the routes that need protection.
 3. **Pick the identifier deliberately** - `ip_identifier` for anonymous traffic,
    or a small custom callable keyed by user / API key for authenticated traffic.
-4. **Enable `trust_proxy` only behind a proxy you control**, never on a directly
-   exposed app.
+4. **Configure proxy headers at the ASGI server**, not in the limiter - Uvicorn
+   `--proxy-headers` with a narrow `--forwarded-allow-ips`.  Never key a limit on
+   raw `X-Forwarded-For`; see [Behind a proxy](#behind-a-proxy).
 5. **Keep fail-open** unless rejecting traffic during a Redis outage is genuinely
    safer for your API than allowing it.
 6. **Use an explicit `scope`** when a group of routes should draw from one

--- a/src/redis_fastapi/__init__.py
+++ b/src/redis_fastapi/__init__.py
@@ -27,6 +27,7 @@ from redis_fastapi.deps import (
 from redis_fastapi.lifespan import redis_lifespan
 from redis_fastapi.rate import Rate, parse_rate
 from redis_fastapi.ratelimit import (
+    CannotIdentifyClient,
     Identifier,
     RateLimitExceeded,
     RateLimitMiddleware,
@@ -53,6 +54,7 @@ __all__ = [
     "CacheBackend",
     "CacheBackendDep",
     "CacheHitException",
+    "CannotIdentifyClient",
     "Coder",
     "Identifier",
     "JsonCoder",

--- a/src/redis_fastapi/config.py
+++ b/src/redis_fastapi/config.py
@@ -165,14 +165,6 @@ class RedisSettings(BaseSettings):
         default=False,
         description=("Emit IETF draft RateLimit / RateLimit-Policy response headers."),
     )
-    rate_limit_trust_proxy: bool = Field(
-        default=False,
-        description=(
-            "Trust the X-Forwarded-For header when deriving the client IP "
-            "(enable only behind a trusted proxy/load balancer)."
-        ),
-    )
-
     # -- Telemetry -------------------------------------------------------------
     otel_enabled: bool = Field(
         default=False,

--- a/src/redis_fastapi/ratelimit.py
+++ b/src/redis_fastapi/ratelimit.py
@@ -6,6 +6,8 @@ Exposes:
 * :class:`RateLimitMiddleware` - an app-wide global limiter / header injector,
 * :func:`ip_identifier` - the ready-made default key strategy (pass your own
   callable via ``identifier=`` to key by user, API key, etc.),
+* :class:`CannotIdentifyClient` - raise it from an identifier that cannot tell
+  callers apart, instead of returning a shared placeholder identity,
 * :class:`RateLimitExceeded` - the control-flow exception returning a 429,
 * :func:`add_redis_rate_limiting` - one-time app wiring.
 
@@ -73,34 +75,64 @@ class _RateLimitState:
 # ---------------------------------------------------------------------------
 
 
-def _client_ip(request: Request, *, trust_proxy: bool | None = None) -> str:
-    """Return the client IP, honoring ``X-Forwarded-For`` when trusted.
+class CannotIdentifyClient(Exception):
+    """Raised by an :data:`Identifier` that cannot determine who the caller is.
 
-    Args:
-        request: The incoming request.
-        trust_proxy: Override the ``REDIS_RATE_LIMIT_TRUST_PROXY`` setting.
+    Rate limiting is only meaningful once callers can be told apart.  When an
+    identifier cannot do that, the alternative to raising is to invent a
+    placeholder identity — and every request carrying it then shares **one**
+    counter, so a single limit throttles the whole application.  That is a
+    self-inflicted outage that looks like a working limiter, which is why this
+    is an exception rather than a fallback string.
+
+    :func:`ip_identifier` raises it when ``request.client`` is absent from the
+    ASGI scope.  Custom identifiers should raise it for the same reason — an
+    unauthenticated request to a per-user limiter, say — rather than returning
+    ``"anonymous"``, unless sharing one bucket is genuinely what you want.
+
+    The limiter treats it exactly like a Redis outage: the check is reported as
+    ``degraded``, and ``fail_closed`` decides the outcome.  Fail-open (the
+    default) lets the request through uncounted; fail-closed rejects it with a
+    429.  Either way the request is **not** counted against a shared bucket, and
+    the ``ratelimit.requests`` metric records ``result="error"`` so the condition
+    is visible instead of silent.
     """
-    trusted = (
-        get_settings().rate_limit_trust_proxy if trust_proxy is None else trust_proxy
-    )
-    if trusted:
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-    if request.client is not None:
-        return request.client.host
-    return "unknown"
 
 
 def ip_identifier(request: Request) -> str:
-    """Default identifier: the client IP.
+    """Default identifier: the client IP from the ASGI scope.
 
     Returns the per-client identity **only**.  The counter is separated per
     route by the *scope* segment (which :func:`rate_limit` defaults to the
     matched route template), so identifiers stay path-agnostic.  Matches the
     :data:`Identifier` signature.
+
+    Reads ``request.client`` and **never** parses ``X-Forwarded-For``.  That
+    header is client-supplied, and the proxies that set it (nginx, ALB, GCP LB)
+    *append* to it rather than overwrite, so its left-most hop is
+    attacker-controlled even in a correctly configured deployment — keying a
+    limit on it would let any caller pick its own counter, or exhaust a
+    victim's.  Proxy trust belongs to the ASGI server, which is the only layer
+    that knows the deployment topology: configure it there (Uvicorn's
+    ``--proxy-headers`` with ``--forwarded-allow-ips``) and ``request.client``
+    reflects the real client for free, because Starlette reads it from the
+    scope the server rewrote.  For servers without that feature, supply your
+    own ``identifier=`` — see ``docs/guide/rate-limiting.md`` § Behind a proxy.
+
+    Raises:
+        CannotIdentifyClient: If ``request.client`` is absent from the ASGI
+            scope.  Populating it is optional in the ASGI spec, and some
+            serverless adapters and test transports leave it ``None``; keying
+            every such request on a shared placeholder would collapse all of
+            them into one counter.
     """
-    return _client_ip(request)
+    if request.client is None:
+        raise CannotIdentifyClient(
+            "The ASGI scope carries no client address, so callers cannot be "
+            "told apart by IP. Pass a different identifier= to rate_limit(), "
+            "or run behind a server that populates scope['client']."
+        )
+    return request.client.host
 
 
 def _route_scope(request: Request) -> str:
@@ -262,6 +294,10 @@ async def _apply_limit(
     identity, run ``backend.hit`` inside a timed span, stash the result on
     ``request.state`` for header injection, and record the metric.
 
+    An identifier that raises :class:`CannotIdentifyClient` short-circuits the
+    counter entirely and yields a ``degraded`` result governed by *fail_closed*,
+    the same treatment an unreachable Redis gets.
+
     Returns the 429 :class:`~starlette.responses.Response` when the request is
     over the limit, or ``None`` when it is allowed or bypassed.  Callers decide
     what to do with a returned response — the dependency raises it as
@@ -277,22 +313,44 @@ async def _apply_limit(
             return None
 
     # The identity is per-client only; route separation lives in the scope.
-    identity = await _resolve_identifier(identifier, request)
-    with ratelimit_span(
-        span_name,
-        attributes={"ratelimit.scope": scope, "ratelimit.limit": rate.limit},
-    ) as span:
-        with timed_rate_limit(scope):
-            result = await backend.hit(
-                identity,
-                limit=rate.limit,
-                window=rate.window,
-                scope=scope,
-                cost=cost,
-                fail_closed=fail_closed,
-            )
-        if span is not None and result.backend:
-            span.set_attribute("ratelimit.backend", result.backend)
+    try:
+        identity = await _resolve_identifier(identifier, request)
+    except CannotIdentifyClient as exc:
+        # No identity means there is no counter to consult, so this takes the
+        # same fail-open/fail-closed path as a Redis outage.  The alternative -
+        # counting every unidentifiable caller under one placeholder identity -
+        # would let a single limit throttle all of them together.
+        closed = (
+            get_settings().rate_limit_fail_closed
+            if fail_closed is None
+            else fail_closed
+        )
+        logger.warning(
+            "Rate-limit identifier could not identify the caller for scope %r "
+            "(fail_%s): %s",
+            scope,
+            "closed" if closed else "open",
+            exc,
+        )
+        result = RateLimitBackend.degraded_result(
+            rate.limit, rate.window, allowed=not closed
+        )
+    else:
+        with ratelimit_span(
+            span_name,
+            attributes={"ratelimit.scope": scope, "ratelimit.limit": rate.limit},
+        ) as span:
+            with timed_rate_limit(scope):
+                result = await backend.hit(
+                    identity,
+                    limit=rate.limit,
+                    window=rate.window,
+                    scope=scope,
+                    cost=cost,
+                    fail_closed=fail_closed,
+                )
+            if span is not None and result.backend:
+                span.set_attribute("ratelimit.backend", result.backend)
 
     _store_state(
         request, _RateLimitState(result, rate.window, emit_headers, ietf_headers)

--- a/src/redis_fastapi/ratelimit_backend.py
+++ b/src/redis_fastapi/ratelimit_backend.py
@@ -132,11 +132,13 @@ class RateLimitResult:
         backend: Which execution path served the check — ``"increx"`` or
             ``"lua"``.  Empty for non-consuming reads
             (:meth:`RateLimitBackend.peek`) and the Redis-unreachable path.
-        degraded: ``True`` when Redis was unreachable and this result is a
-            fail-open/fail-closed fallback rather than a real counter check.
-            Lets callers distinguish a genuine ``allowed``/``limited`` outcome
-            from one produced during an outage (e.g. to record an ``error``
-            metric or add a header).
+        degraded: ``True`` when no counter could be consulted and this result is
+            a fail-open/fail-closed fallback rather than a real check — Redis was
+            unreachable, or the caller could not be identified
+            (:class:`~redis_fastapi.ratelimit.CannotIdentifyClient`).  Lets
+            callers distinguish a genuine ``allowed``/``limited`` outcome from
+            one produced during an outage (e.g. to record an ``error`` metric or
+            add a header).
     """
 
     allowed: bool
@@ -248,7 +250,7 @@ class RateLimitBackend:
                 "closed" if closed else "open",
                 exc_info=True,
             )
-            return self._degraded_result(limit, window, allowed=not closed)
+            return self.degraded_result(limit, window, allowed=not closed)
 
         allowed = actual_incr != 0
         # PTTL is -1 (no expiry) or -2 (missing) in edge cases; treat as a
@@ -350,8 +352,16 @@ class RateLimitBackend:
         return int(result[0]), int(result[1]), int(result[2])
 
     @staticmethod
-    def _degraded_result(limit: int, window: int, *, allowed: bool) -> RateLimitResult:
-        """Build a result for the Redis-unreachable path."""
+    def degraded_result(limit: int, window: int, *, allowed: bool) -> RateLimitResult:
+        """Build a fallback result for a check that could not be counted.
+
+        Used when the limiter cannot consult a real counter: Redis was
+        unreachable, or the caller could not be identified at all (see
+        :class:`~redis_fastapi.ratelimit.CannotIdentifyClient`).  *allowed*
+        carries the fail-open / fail-closed decision, and ``degraded=True``
+        keeps the outcome distinguishable from a genuine check so callers can
+        record an ``error`` metric rather than a normal allow/limit.
+        """
         return RateLimitResult(
             allowed=allowed,
             limit=limit,
@@ -392,7 +402,7 @@ class RateLimitBackend:
             pttl_ms = int(await self._redis.pttl(full_key))
         except (RedisError, OSError):
             logger.warning("Error reading rate-limit key '%s'", full_key, exc_info=True)
-            return self._degraded_result(limit, window, allowed=not self._fail_closed)
+            return self.degraded_result(limit, window, allowed=not self._fail_closed)
         current = int(raw) if raw is not None else 0
         reset_after = math.ceil(pttl_ms / 1000) if pttl_ms > 0 else window
         return RateLimitResult(

--- a/tests/integration/test_ratelimit_di.py
+++ b/tests/integration/test_ratelimit_di.py
@@ -8,21 +8,18 @@ and the ``X-RateLimit-*`` / IETF ``RateLimit`` headers — through ``TestClient`
 against a **real Redis server**.
 
 Each test builds its own app, keys counters off the request identity (the
-``TestClient`` client host, or an ``X-Forwarded-For`` value when trusting a
-proxy), and flushes the DB on teardown so counters never leak between tests.
+``TestClient`` client host), and flushes the DB on teardown so counters never
+leak between tests.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 import redis as sync_redis
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from redis_fastapi import FastAPIRedis, rate_limit
-from redis_fastapi.config import RedisSettings
 from tests.conftest import requires_redis
 
 
@@ -112,11 +109,19 @@ class TestRateLimitDependency:
 
 @requires_redis
 @pytest.mark.integration
-class TestTrustProxy:
-    """``rate_limit_trust_proxy`` controls whether X-Forwarded-For sets identity."""
+class TestProxyHeadersAreNotTrusted:
+    """``X-Forwarded-For`` never sets the rate-limit identity.
 
-    def test_disabled_ignores_xff(self, real_redis: sync_redis.Redis) -> None:
-        """Default (untrusted): XFF is ignored, so all callers share one bucket."""
+    Regression guard for the removed ``REDIS_RATE_LIMIT_TRUST_PROXY`` flag,
+    which keyed the counter on the header's **left-most** hop.  Proxies append
+    to XFF rather than overwrite it, so that hop is caller-supplied even behind
+    a correctly configured proxy — a client could rotate identities to evade its
+    own limit, or forge a victim's to exhaust theirs.  Proxy trust now belongs
+    to the ASGI server; these tests pin the header out of the identity.
+    """
+
+    def test_varying_xff_shares_one_counter(self, real_redis: sync_redis.Redis) -> None:
+        """Different XFF values from one peer hit the same bucket."""
         app = FastAPI()
         FastAPIRedis(app).lifespan().rate_limiting()
 
@@ -126,7 +131,6 @@ class TestTrustProxy:
 
         try:
             with TestClient(app) as tc:
-                # Different XFF values, but the setting is off -> same counter.
                 first = tc.get("/limited", headers={"X-Forwarded-For": "9.9.9.9"})
                 second = tc.get("/limited", headers={"X-Forwarded-For": "8.8.8.8"})
             assert first.status_code == 200
@@ -134,28 +138,73 @@ class TestTrustProxy:
         finally:
             real_redis.flushdb()
 
-    def test_enabled_keys_by_xff(self, real_redis: sync_redis.Redis) -> None:
-        """Trusted: each X-Forwarded-For client gets its own counter."""
-        trusting = RedisSettings(rate_limit_trust_proxy=True)
-        # `_client_ip` reads the setting at request time via ratelimit.get_settings;
-        # patch it there and build the dependency under the patch.
-        with patch("redis_fastapi.ratelimit.get_settings", return_value=trusting):
-            app = FastAPI()
-            FastAPIRedis(app).lifespan().rate_limiting()
+    def test_no_setting_re_enables_per_xff_keying(
+        self, real_redis: sync_redis.Redis
+    ) -> None:
+        """Rotation is impossible by configuration, not merely off by default."""
+        app = FastAPI()
+        FastAPIRedis(app).lifespan().rate_limiting()
 
-            @app.get("/limited", dependencies=[Depends(rate_limit("1/minute"))])
-            async def limited() -> dict[str, str]:
-                return {"ok": "yes"}
+        @app.get("/limited", dependencies=[Depends(rate_limit("2/minute"))])
+        async def limited() -> dict[str, str]:
+            return {"ok": "yes"}
 
-            try:
-                with TestClient(app) as tc:
-                    # Two distinct proxied clients: each allowed once.
-                    a1 = tc.get("/limited", headers={"X-Forwarded-For": "9.9.9.9"})
-                    b1 = tc.get("/limited", headers={"X-Forwarded-For": "8.8.8.8"})
-                    # The first client's second request exhausts its own bucket.
-                    a2 = tc.get("/limited", headers={"X-Forwarded-For": "9.9.9.9"})
-                assert a1.status_code == 200
-                assert b1.status_code == 200  # separate counter, not shared
-                assert a2.status_code == 429
-            finally:
-                real_redis.flushdb()
+        try:
+            with TestClient(app) as tc:
+                # Three distinct forged hops against a limit of 2.  Under the old
+                # flag each opened its own counter and all three passed.
+                codes = [
+                    tc.get("/limited", headers={"X-Forwarded-For": hop}).status_code
+                    for hop in ("9.9.9.9", "8.8.8.8", "7.7.7.7")
+                ]
+            assert codes == [200, 200, 429]
+        finally:
+            real_redis.flushdb()
+
+    def test_custom_identifier_can_opt_into_proxy_awareness(
+        self, real_redis: sync_redis.Redis
+    ) -> None:
+        """The documented escape hatch for servers without proxy-header support.
+
+        Mirrors the recipe in ``docs/guide/rate-limiting.md`` § Behind a proxy:
+        gate on the immediate peer, then walk XFF right-to-left for the first
+        hop the trust list does not cover.
+        """
+        trusted_peers = frozenset({"testclient"})
+
+        def xff_identifier(request: Request) -> str:
+            peer = request.client.host if request.client is not None else ""
+            if peer not in trusted_peers:
+                return peer  # untrusted peer: its own address is the identity
+            hops = [
+                hop.strip()
+                for hop in request.headers.get("X-Forwarded-For", "").split(",")
+                if hop.strip()
+            ]
+            for hop in reversed(hops):
+                if hop not in trusted_peers:
+                    return hop
+            return peer
+
+        app = FastAPI()
+        FastAPIRedis(app).lifespan().rate_limiting()
+
+        @app.get(
+            "/limited",
+            dependencies=[Depends(rate_limit("1/minute", identifier=xff_identifier))],
+        )
+        async def limited() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        try:
+            with TestClient(app) as tc:
+                # The peer is trusted here, so the forwarded hop is honoured and
+                # the two proxied clients get separate counters.
+                a1 = tc.get("/limited", headers={"X-Forwarded-For": "9.9.9.9"})
+                b1 = tc.get("/limited", headers={"X-Forwarded-For": "8.8.8.8"})
+                a2 = tc.get("/limited", headers={"X-Forwarded-For": "9.9.9.9"})
+            assert a1.status_code == 200
+            assert b1.status_code == 200
+            assert a2.status_code == 429
+        finally:
+            real_redis.flushdb()

--- a/tests/unit/test_ratelimit.py
+++ b/tests/unit/test_ratelimit.py
@@ -12,10 +12,11 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 
 from redis_fastapi.deps import get_rate_limit_backend
 from redis_fastapi.ratelimit import (
+    CannotIdentifyClient,
     RateLimitResult,
-    _client_ip,
     _metric_result,
     ip_identifier,
+    rate_limit,
 )
 from redis_fastapi.ratelimit_backend import RateLimitBackend
 from redis_fastapi.setup import FastAPIRedis
@@ -51,8 +52,9 @@ def fake(
 
 
 def _request(
-    headers: dict[str, str] | None = None, client_host: str = "1.1.1.1"
+    headers: dict[str, str] | None = None, client_host: str | None = "1.1.1.1"
 ) -> Request:
+    """Build a bare ASGI request; ``client_host=None`` omits ``scope["client"]``."""
     scope = {
         "type": "http",
         "method": "GET",
@@ -60,21 +62,40 @@ def _request(
         "headers": [
             (k.lower().encode(), v.encode()) for k, v in (headers or {}).items()
         ],
-        "client": (client_host, 12345),
+        "client": None if client_host is None else (client_host, 12345),
         "query_string": b"",
     }
     return Request(scope)
 
 
+def _no_identity(request: Request) -> str:
+    """Identifier standing in for a scope with no client address."""
+    raise CannotIdentifyClient("no client address in the ASGI scope")
+
+
 @pytest.mark.unit
 class TestIdentifiers:
-    def test_client_ip_ignores_xff_by_default(self) -> None:
-        req = _request({"X-Forwarded-For": "9.9.9.9"})
-        assert _client_ip(req, trust_proxy=False) == "1.1.1.1"
-
-    def test_client_ip_honours_xff_when_trusted(self) -> None:
+    def test_ip_identifier_never_reads_x_forwarded_for(self) -> None:
+        # XFF is never consulted, with or without configuration.  Proxies
+        # *append* to the header, so its left-most hop is whatever the caller
+        # sent; keying on it would let a client pick its own counter (bypass) or
+        # a victim's (targeted exhaustion).  Proxy trust belongs to the ASGI
+        # server — see docs/guide/rate-limiting.md § Behind a proxy.
         req = _request({"X-Forwarded-For": "9.9.9.9, 10.0.0.1"})
-        assert _client_ip(req, trust_proxy=True) == "9.9.9.9"
+        assert ip_identifier(req) == "1.1.1.1"
+
+    def test_ip_identifier_gives_one_bucket_across_forged_xff(self) -> None:
+        # The same peer cannot rotate identities by varying the header.
+        assert ip_identifier(_request({"X-Forwarded-For": "9.9.9.9"})) == ip_identifier(
+            _request({"X-Forwarded-For": "8.8.8.8"})
+        )
+
+    def test_ip_identifier_follows_scope_client(self) -> None:
+        # Uvicorn's ProxyHeadersMiddleware rewrites scope["client"] once for the
+        # whole app, and Starlette reads request.client straight from the scope.
+        # So the real client IP flows through here with no parsing of our own —
+        # this is what replaces the removed REDIS_RATE_LIMIT_TRUST_PROXY flag.
+        assert ip_identifier(_request(client_host="203.0.113.7")) == "203.0.113.7"
 
     def test_ip_identifier_is_client_ip_only(self) -> None:
         # Route separation lives in the scope (default: the route template), not
@@ -90,6 +111,112 @@ class TestIdentifiers:
         req = _request({"X-API-Key": "abc123"})
         assert api_key_identifier(req) == "abc123"
         assert api_key_identifier(_request()) == "anonymous"
+
+
+@pytest.mark.unit
+class TestUnidentifiableClient:
+    """A caller the identifier cannot name is degraded, never bucketed together.
+
+    ``scope["client"]`` is optional in the ASGI spec; serverless adapters and some
+    test transports leave it ``None``.  Keying those requests on a shared
+    placeholder would collapse every one of them into a single counter, so one
+    limit would throttle the whole app.  Instead the check is reported as
+    ``degraded`` and ``fail_closed`` decides the outcome.
+    """
+
+    def test_ip_identifier_raises_without_a_client(self) -> None:
+        with pytest.raises(CannotIdentifyClient):
+            ip_identifier(_request(client_host=None))
+
+    def test_fails_open_uncounted_by_default(
+        self, fake: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        """Fail-open: allowed through, and not counted against any bucket."""
+        app = _build_app(fake)
+
+        @app.get(
+            "/u",
+            dependencies=[Depends(rate_limit("1/minute", identifier=_no_identity))],
+        )
+        async def u() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        with TestClient(app) as client:
+            # A limit of 1 would reject the second request had these shared a
+            # placeholder bucket; both pass because neither was counted at all.
+            assert client.get("/u").status_code == 200
+            assert client.get("/u").status_code == 200
+
+    def test_fails_closed_when_configured(
+        self, fake: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        app = _build_app(fake)
+
+        @app.get(
+            "/u",
+            dependencies=[
+                Depends(
+                    rate_limit("1/minute", identifier=_no_identity, fail_closed=True)
+                )
+            ],
+        )
+        async def u() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        with TestClient(app) as client:
+            assert client.get("/u").status_code == 429
+
+    def test_recorded_as_an_error_not_an_allow(
+        self, fake: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        """The condition is visible in metrics rather than silently passing."""
+        app = _build_app(fake)
+
+        @app.get(
+            "/u",
+            dependencies=[Depends(rate_limit("1/minute", identifier=_no_identity))],
+        )
+        async def u() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        with (
+            patch("redis_fastapi.ratelimit.record_rate_limit_request") as spy,
+            TestClient(app) as client,
+        ):
+            assert client.get("/u").status_code == 200
+
+        recorded = [call.kwargs.get("result") for call in spy.call_args_list]
+        assert "error" in recorded
+        assert "allowed" not in recorded
+
+    def test_custom_identifier_may_raise_it(
+        self, fake: fakeredis.aioredis.FakeRedis
+    ) -> None:
+        """The escape hatch is public: a per-user limiter can refuse anonymous
+        callers instead of pooling them under one ``"anonymous"`` identity."""
+
+        def user_identifier(request: Request) -> str:
+            user = request.headers.get("X-User")
+            if not user:
+                raise CannotIdentifyClient("no authenticated user on the request")
+            return f"user:{user}"
+
+        app = _build_app(fake)
+
+        @app.get(
+            "/me",
+            dependencies=[Depends(rate_limit("1/minute", identifier=user_identifier))],
+        )
+        async def me() -> dict[str, str]:
+            return {"ok": "yes"}
+
+        with TestClient(app) as client:
+            # Identified callers are counted normally...
+            assert client.get("/me", headers={"X-User": "a"}).status_code == 200
+            assert client.get("/me", headers={"X-User": "a"}).status_code == 429
+            # ...while an unidentified one is degraded, not merged into a bucket.
+            assert client.get("/me").status_code == 200
+            assert client.get("/me").status_code == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

Fixes #38.

### Breaking: `REDIS_RATE_LIMIT_TRUST_PROXY` is gone

The flag keyed rate limits on the **left-most** `X-Forwarded-For` hop. Proxies (nginx, ALB, GCP LB) *append* to that header rather than overwrite it, so the left-most entry is whatever the caller sent - even behind a correctly configured
proxy. Any client could rotate identities to evade its own limit, or forge a victim's address to exhaust theirs.

`ip_identifier` now returns `request.client.host` and never reads the header.

**If you had the flag set:**

| Setup | Do this |
|---|---|
| Uvicorn / Gunicorn+Uvicorn | `--proxy-headers --forwarded-allow-ips=<your proxy CIDR>` |
| Other ASGI servers | Pass a custom `identifier=` ([recipe in the guide](https://redis.github.io/fastapi-redis-sdk/guide/rate-limiting/#behind-a-proxy)) |

A leftover env var is silently ignored - the new behaviour is the safe one, but it won't warn you. Counter keys change, so in-flight windows reset once on deploy.

### Unidentifiable clients no longer share one bucket

When the ASGI scope has no client address (some serverless adapters, test transports), the limiter used to key every such request on `"unknown"` - one counter for the whole application, so a `100/minute` limit throttled *all* traffic to 100/minute. No attacker or misconfiguration required.

Those checks are now degraded instead: allowed-but-uncounted by default, `429` under `fail_closed=True`, and recorded as `error` in metrics either way.

New public `CannotIdentifyClient` - raise it from your own identifiers rather than returning a placeholder:

```python
from redis_fastapi import CannotIdentifyClient

def user_identifier(request):
    user = getattr(request.state, "user", None)
    if user is None:
        raise CannotIdentifyClient("no authenticated user")
    return f"user:{user.id}"
```

### Docs

Rewrote Behind a proxy in the rate-limiting guide: why the SDK doesn't parse X-Forwarded-For, Uvicorn setup, a peer-gated recipe for other servers, CDN headers, and a migration table.